### PR TITLE
Add Bindings for Memory Computation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/relations/arithmetic_programs/qap.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/relations/arithmetic_programs/sap.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/relations/arithmetic_programs/ssp.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/relations/ram_computations/memory/memory.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/r1cs_to_qap.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/uscs_to_ssp.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -20,8 +20,7 @@ void init_relations_circuit_satisfaction_problems_tbcs_examples(py::module &);
 void init_relations_arithmetic_programs_qap(py::module &);
 void init_relations_arithmetic_programs_sap(py::module &);
 void init_relations_arithmetic_programs_ssp(py::module &);
-void init_relations_ram_computations_memory_store_trace(py::module &);
-void init_relations_ram_computations_ra_memory(py::module &);
+void init_relations_ram_computations_memory(py::module &);
 void init_reductions_r1cs_to_qap(py::module &);
 void init_reductions_uscs_to_ssp(py::module &);
 
@@ -48,8 +47,7 @@ PYBIND11_MODULE(pyzpk, m)
     init_relations_arithmetic_programs_qap(m);
     init_relations_arithmetic_programs_sap(m);
     init_relations_arithmetic_programs_ssp(m);
-    init_relations_ram_computations_memory_store_trace(m);
-    init_relations_ram_computations_ra_memory(m);
+    init_relations_ram_computations_memory(m);
     init_reductions_r1cs_to_qap(m);
     init_reductions_uscs_to_ssp(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -20,6 +20,8 @@ void init_relations_circuit_satisfaction_problems_tbcs_examples(py::module &);
 void init_relations_arithmetic_programs_qap(py::module &);
 void init_relations_arithmetic_programs_sap(py::module &);
 void init_relations_arithmetic_programs_ssp(py::module &);
+void init_relations_ram_computations_memory_store_trace(py::module &);
+void init_relations_ram_computations_ra_memory(py::module &);
 void init_reductions_r1cs_to_qap(py::module &);
 void init_reductions_uscs_to_ssp(py::module &);
 
@@ -46,6 +48,8 @@ PYBIND11_MODULE(pyzpk, m)
     init_relations_arithmetic_programs_qap(m);
     init_relations_arithmetic_programs_sap(m);
     init_relations_arithmetic_programs_ssp(m);
+    init_relations_ram_computations_memory_store_trace(m);
+    init_relations_ram_computations_ra_memory(m);
     init_reductions_r1cs_to_qap(m);
     init_reductions_uscs_to_ssp(m);
 }

--- a/src/PyZPK/relations/ram_computations/memory/memory.cpp
+++ b/src/PyZPK/relations/ram_computations/memory/memory.cpp
@@ -8,16 +8,17 @@ namespace py = pybind11;
 using namespace libsnark;
 
 //  A list in which each component consists of a timestamp and a memory store.
-void init_relations_ram_computations_memory_store_trace(py::module &m)
+void declare_memory_store_trace(py::module &m)
 {
     py::class_<memory_store_trace>(m, "memory_store_trace")
         .def(py::init<>())
         .def("get_trace_entry", &memory_store_trace::get_trace_entry, py::arg("timestamp"))
-        .def("set_trace_entry", &memory_store_trace::set_trace_entry, py::arg("timestamp"), py::arg("address_and_value"));
+        .def("set_trace_entry", &memory_store_trace::set_trace_entry, py::arg("timestamp"),
+             py::arg("address_and_value"));
 }
 
 // A random-access memory maintains the memory's contents via a map (from addresses to values).
-void init_relations_ram_computations_ra_memory(py::module &m)
+void declare_ra_memory(py::module &m)
 {
     py::class_<ra_memory>(m, "ra_memory")
         .def(py::init<const size_t, const size_t>())
@@ -26,4 +27,10 @@ void init_relations_ram_computations_ra_memory(py::module &m)
 
         .def("get_value", &ra_memory::get_value, py::arg("address"))
         .def("set_value", &ra_memory::set_value, py::arg("address"), py::arg("value"));
+}
+
+void init_relations_ram_computations_memory(py::module &m)
+{
+    declare_memory_store_trace(m);
+    declare_ra_memory(m);
 }

--- a/src/PyZPK/relations/ram_computations/memory/memory.cpp
+++ b/src/PyZPK/relations/ram_computations/memory/memory.cpp
@@ -1,0 +1,28 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <vector>
+#include <libsnark/relations/ram_computations/memory/memory_store_trace.hpp>
+#include <libsnark/relations/ram_computations/memory/ra_memory.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+
+//  A list in which each component consists of a timestamp and a memory store.
+void init_relations_ram_computations_memory_store_trace(py::module &m)
+{
+    py::class_<memory_store_trace>(m, "memory_store_trace")
+        .def(py::init<>())
+        .def("get_trace_entry", &memory_store_trace::get_trace_entry, py::arg("timestamp"))
+        .def("set_trace_entry", &memory_store_trace::set_trace_entry, py::arg("timestamp"), py::arg("address_and_value"));
+}
+
+void init_relations_ram_computations_ra_memory(py::module &m)
+{
+    py::class_<ra_memory>(m, "ra_memory")
+        .def(py::init<const size_t, const size_t>())
+        .def(py::init<const size_t, const size_t, const std::vector<size_t> &>())
+        .def(py::init<const size_t, const size_t, const memory_contents &>())
+
+        .def("get_value", &ra_memory::get_value, py::arg("address"))
+        .def("set_value", &ra_memory::set_value, py::arg("address"), py::arg("value"));
+}

--- a/src/PyZPK/relations/ram_computations/memory/memory.cpp
+++ b/src/PyZPK/relations/ram_computations/memory/memory.cpp
@@ -16,6 +16,7 @@ void init_relations_ram_computations_memory_store_trace(py::module &m)
         .def("set_trace_entry", &memory_store_trace::set_trace_entry, py::arg("timestamp"), py::arg("address_and_value"));
 }
 
+// A random-access memory maintains the memory's contents via a map (from addresses to values).
 void init_relations_ram_computations_ra_memory(py::module &m)
 {
     py::class_<ra_memory>(m, "ra_memory")

--- a/test/test_ram_computation.py
+++ b/test/test_ram_computation.py
@@ -1,0 +1,33 @@
+import random
+import pytest
+import pyzpk
+import math
+
+# simple test cases.
+# 1. Insert some random address and values in the memory
+# 2. Test whether the new insertion is not affecting already existing values.
+def test_memory():
+    memory_trace = pyzpk.memory_store_trace()
+    ra_memory = pyzpk.ra_memory(10,10)
+    timestamp = 0
+    address = 4001
+    value = 0
+    while(timestamp < 10):
+        memory_trace.set_trace_entry(timestamp, (address, value))
+        ra_memory.set_value(address, value)
+        timestamp += 1
+        address += 8
+        value += 100
+
+    timestamp = 0
+    address = 4001
+    value = 0
+    while(timestamp < 10):
+        address_and_value = memory_trace.get_trace_entry(timestamp)
+        value = ra_memory.get_value(address)
+        assert address_and_value[0] == address
+        assert address_and_value[1] == value
+        assert value == value
+        timestamp += 1
+        address += 8
+        value += 100

--- a/test/test_ram_computation.py
+++ b/test/test_ram_computation.py
@@ -2,13 +2,16 @@ import random
 import pytest
 import pyzpk
 import math
+RAND_MAX = 32767
 
 # simple test cases.
 # 1. Insert some random address and values in the memory
 # 2. Test whether the new insertion is not affecting already existing values.
+
+
 def test_memory():
     memory_trace = pyzpk.memory_store_trace()
-    ra_memory = pyzpk.ra_memory(10,10)
+    ra_memory = pyzpk.ra_memory(10, 10)
     timestamp = 0
     address = 4001
     value = 0
@@ -31,3 +34,29 @@ def test_memory():
         timestamp += 1
         address += 8
         value += 100
+
+
+@pytest.mark.parametrize("num_addresses, value_size, block1_size, block2_size",
+                         [(10, 20, 5, 5)])
+def test_block_memory_contents(num_addresses, value_size, block1_size, block2_size):
+    max_unit = 1 << value_size
+    result = dict()
+    for i in range(0, block1_size):
+        result[i] = random.randint(0, RAND_MAX) % max_unit
+    for i in range(0, block2_size):
+        result[num_addresses//2+i] = random.randint(0, RAND_MAX) % max_unit
+
+
+@pytest.mark.parametrize("num_addresses, value_size, num_filled",
+                         [(10, 20, 5)])
+def test_random_memory_contents(num_addresses, value_size, num_filled):
+    max_unit = 1 << value_size
+    unfilled = list()
+    for i in range(0, num_addresses):
+        unfilled.append(i)
+
+    result = dict()
+    for i in range(0, num_filled):
+        i = i + random.randint(0, RAND_MAX) % len(unfilled)
+        result[i] = random.randint(0, RAND_MAX) % max_unit
+        unfilled.remove(unfilled[i % len(unfilled)])

--- a/test/test_tbcs.py
+++ b/test/test_tbcs.py
@@ -34,15 +34,9 @@ def test_tbcs_gate_type_enum():
                          [(10, 10, 20, 5)])
 def test_tbcs(primary_input_size, auxiliary_input_size, num_gates, num_outputs):
     assert num_outputs <= num_gates
-    primary_input_size = 10
-    auxiliary_input_size = 10
-    num_gates = 20
-    num_outputs = 5
     RAND_MAX = 32767
     num_tbcs_gate_types = 16
-
     example = pyzpk.tbcs_example()
-
     primary_input_list = list()
     auxiliary_input_list = list()
     for i in range(0, primary_input_size):


### PR DESCRIPTION
## Description
- Add bindings for memory computation.
- Implemented sample test cases for memory computation.

closes #8 
## How has this been tested?
- This can be tested by running `pytest test` from the root folder.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
