### PR TITLE
Add Bindings for gadgetlib1 utils and bacs_to_r1cs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,9 +22,10 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/relations/ram_computations/memory/memory.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/relations/ram_computations/rams/tinyram.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/relations/ram_computations/rams/fooram.cpp"
-  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/r1cs_to_qap.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/uscs_to_ssp.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/r1cs_to_qap.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/bacs_to_r1cs.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/constraint_profiling.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/bacs_to_r1cs.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/constraint_profiling.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/protoboard.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/relations/ram_computations/rams/fooram.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/r1cs_to_qap.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/uscs_to_ssp.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/bacs_to_r1cs.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/r1cs_to_qap.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/reductions/bacs_to_r1cs.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/constraint_profiling.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/constraint_profiling.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/protoboard.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/pb_variable.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -27,6 +27,7 @@ void init_reductions_bacs_to_r1cs(py::module &);
 void init_reductions_r1cs_to_qap(py::module &);
 void init_reductions_uscs_to_ssp(py::module &);
 void init_gadgetlib1_constraint_profiling(py::module &);
+void init_gadgetlib1_gadget(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -58,4 +59,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_reductions_r1cs_to_qap(m);
     init_reductions_uscs_to_ssp(m);
     init_gadgetlib1_constraint_profiling(m);
+    init_gadgetlib1_gadget(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -23,9 +23,10 @@ void init_relations_arithmetic_programs_ssp(py::module &);
 void init_relations_ram_computations_memory(py::module &);
 void init_relations_ram_computations_rams_tinyram(py::module &);
 void init_relations_ram_computations_rams_fooram(py::module &);
+void init_reductions_bacs_to_r1cs(py::module &);
 void init_reductions_r1cs_to_qap(py::module &);
 void init_reductions_uscs_to_ssp(py::module &);
-void init_reductions_bacs_to_r1cs(py::module &);
+void init_gadgetlib1_constraint_profiling(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -53,7 +54,8 @@ PYBIND11_MODULE(pyzpk, m)
     init_relations_ram_computations_memory(m);
     init_relations_ram_computations_rams_tinyram(m);
     init_relations_ram_computations_rams_fooram(m);
+    init_reductions_bacs_to_r1cs(m);
     init_reductions_r1cs_to_qap(m);
     init_reductions_uscs_to_ssp(m);
-    init_reductions_bacs_to_r1cs(m);
+    init_gadgetlib1_constraint_profiling(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -25,6 +25,7 @@ void init_relations_ram_computations_rams_tinyram(py::module &);
 void init_relations_ram_computations_rams_fooram(py::module &);
 void init_reductions_r1cs_to_qap(py::module &);
 void init_reductions_uscs_to_ssp(py::module &);
+void init_reductions_bacs_to_r1cs(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -54,4 +55,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_relations_ram_computations_rams_fooram(m);
     init_reductions_r1cs_to_qap(m);
     init_reductions_uscs_to_ssp(m);
+    init_reductions_bacs_to_r1cs(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -29,6 +29,7 @@ void init_reductions_uscs_to_ssp(py::module &);
 void init_gadgetlib1_constraint_profiling(py::module &);
 void init_gadgetlib1_gadget(py::module &);
 void init_gadgetlib1_protoboard(py::module &);
+void init_gadgetlib1_pb_variable(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -62,4 +63,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_constraint_profiling(m);
     init_gadgetlib1_gadget(m);
     init_gadgetlib1_protoboard(m);
+    init_gadgetlib1_pb_variable(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -28,6 +28,7 @@ void init_reductions_r1cs_to_qap(py::module &);
 void init_reductions_uscs_to_ssp(py::module &);
 void init_gadgetlib1_constraint_profiling(py::module &);
 void init_gadgetlib1_gadget(py::module &);
+void init_gadgetlib1_protoboard(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -60,4 +61,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_reductions_uscs_to_ssp(m);
     init_gadgetlib1_constraint_profiling(m);
     init_gadgetlib1_gadget(m);
+    init_gadgetlib1_protoboard(m);
 }

--- a/src/PyZPK/gadgetlib1/constraint_profiling.cpp
+++ b/src/PyZPK/gadgetlib1/constraint_profiling.cpp
@@ -1,0 +1,19 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/gadgetlib1/constraint_profiling.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+
+void init_gadgetlib1_constraint_profiling(py::module &m)
+{
+    m.attr("constraint_profiling_indent") = 0;
+
+    py::class_<constraint_profiling_entry>(m, "constraint_profiling_entry")
+        .def_readwrite("indent", &constraint_profiling_entry::indent)
+        .def_readwrite("annotation", &constraint_profiling_entry::annotation)
+        .def_readwrite("count", &constraint_profiling_entry::count);
+
+    m.def("PRINT_CONSTRAINT_PROFILING", &PRINT_CONSTRAINT_PROFILING, "returns # of top level constraints");
+}

--- a/src/PyZPK/gadgetlib1/gadget.cpp
+++ b/src/PyZPK/gadgetlib1/gadget.cpp
@@ -1,0 +1,17 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadget.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+void init_gadgetlib1_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<gadget<FieldT>>(m, "gadget")
+        .def(py::init<protoboard<FieldT> &, const std::string &>());
+}

--- a/src/PyZPK/gadgetlib1/pb_variable.cpp
+++ b/src/PyZPK/gadgetlib1/pb_variable.cpp
@@ -1,0 +1,75 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/pb_variable.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+void declare_pb_variable(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<pb_variable<FieldT>>(m, "pb_variable")
+        .def(py::init<const var_index_t>())
+        .def("allocate", &pb_variable<FieldT>::allocate, py::arg("protoboard"), py::arg("annotation"));
+}
+
+void declare_pb_variable_array(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<pb_variable_array<FieldT>>(m, "pb_variable_array")
+        .def(py::init<>())
+        .def(py::init<size_t, const pb_variable<FieldT> &>())
+        .def("allocate", &pb_variable_array<FieldT>::allocate, py::arg("protoboard"), py::arg("n"), py::arg("annotation"))
+        .def("fill_with_field_elements", &pb_variable_array<FieldT>::fill_with_field_elements, py::arg("protoboard"), py::arg("vals"))
+        .def("fill_with_bits", &pb_variable_array<FieldT>::fill_with_bits, py::arg("protoboard"), py::arg("bit_vector"))
+        .def("fill_with_bits_of_ulong", &pb_variable_array<FieldT>::fill_with_bits_of_ulong, py::arg("protoboard"), py::arg("i"))
+        .def("fill_with_bits_of_field_element", &pb_variable_array<FieldT>::fill_with_bits_of_field_element, py::arg("protoboard"), py::arg("Field"))
+        .def("get_vals", &pb_variable_array<FieldT>::get_vals, py::arg("protoboard"))
+        .def("get_bits", &pb_variable_array<FieldT>::get_bits, py::arg("protoboard"))
+        .def("get_field_element_from_bits", &pb_variable_array<FieldT>::get_field_element_from_bits, py::arg("protoboard"));
+}
+
+void declare_pb_linear_combination(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<pb_linear_combination<FieldT>>(m, "pb_linear_combination")
+        .def(py::init<>())
+        .def(py::init<const pb_variable<FieldT> &>())
+        .def("assign", &pb_linear_combination<FieldT>::assign, py::arg("protoboard"), py::arg("linear_combination"))
+        .def("evaluate", &pb_linear_combination<FieldT>::evaluate, py::arg("protoboard"))
+        .def("is_constant", &pb_linear_combination<FieldT>::is_constant)
+        .def("constant_term", &pb_linear_combination<FieldT>::constant_term);
+}
+
+void declare_pb_linear_combination_array(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<pb_linear_combination_array<FieldT>>(m, "pb_linear_combination_array")
+        .def(py::init<>())
+        .def(py::init<const pb_variable_array<FieldT> &>())
+        .def(py::init<size_t>())
+        .def(py::init<size_t, const pb_linear_combination<FieldT> &>())
+        .def("evaluate", &pb_linear_combination_array<FieldT>::evaluate, py::arg("protoboard"))
+        .def("fill_with_field_elements", &pb_linear_combination_array<FieldT>::fill_with_field_elements, py::arg("protoboard"), py::arg("vals"))
+        .def("fill_with_bits", &pb_linear_combination_array<FieldT>::fill_with_bits, py::arg("protoboard"), py::arg("bit_vector"))
+        .def("fill_with_bits_of_ulong", &pb_linear_combination_array<FieldT>::fill_with_bits_of_ulong, py::arg("protoboard"), py::arg("i"))
+        .def("fill_with_bits_of_field_element", &pb_linear_combination_array<FieldT>::fill_with_bits_of_field_element, py::arg("protoboard"), py::arg("Field"))
+        .def("get_vals", &pb_linear_combination_array<FieldT>::get_vals, py::arg("protoboard"))
+        .def("get_bits", &pb_linear_combination_array<FieldT>::get_bits, py::arg("protoboard"))
+        .def("get_field_element_from_bits", &pb_linear_combination_array<FieldT>::get_field_element_from_bits, py::arg("protoboard"));
+}
+
+void init_gadgetlib1_pb_variable(py::module &m)
+{
+    declare_pb_variable(m);
+    declare_pb_variable_array(m);
+    declare_pb_linear_combination(m);
+    declare_pb_linear_combination_array(m);
+}

--- a/src/PyZPK/gadgetlib1/protoboard.cpp
+++ b/src/PyZPK/gadgetlib1/protoboard.cpp
@@ -31,5 +31,5 @@ void init_gadgetlib1_protoboard(py::module &m)
         .def("full_variable_assignment", &protoboard<FieldT>::full_variable_assignment)
         .def("primary_input", &protoboard<FieldT>::primary_input)
         .def("auxiliary_input", &protoboard<FieldT>::auxiliary_input)
-        .def("get_constraint_system", &protoboard<FieldT>::get_constraint_system)
+        .def("get_constraint_system", &protoboard<FieldT>::get_constraint_system);
 }

--- a/src/PyZPK/gadgetlib1/protoboard.cpp
+++ b/src/PyZPK/gadgetlib1/protoboard.cpp
@@ -1,0 +1,35 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/protoboard.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+void init_gadgetlib1_protoboard(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<protoboard<FieldT>>(m, "protoboard")
+        .def(py::init<>())
+        .def("clear_values", &protoboard<FieldT>::clear_values)
+        .def("val", py::overload_cast<const pb_variable<FieldT> &>(&protoboard<FieldT>::val), py::arg("var"))
+        .def("val", py::overload_cast<const pb_variable<FieldT> &>(&protoboard<FieldT>::val), py::arg("var"), py::return_value_policy::reference)
+        .def("lc_val", py::overload_cast<const pb_linear_combination<FieldT> &>(&protoboard<FieldT>::lc_val), py::arg("lc"))
+        .def("lc_val", py::overload_cast<const pb_linear_combination<FieldT> &>(&protoboard<FieldT>::lc_val), py::arg("lc"), py::return_value_policy::reference)
+        .def("add_r1cs_constraint", &protoboard<FieldT>::add_r1cs_constraint, py::arg("constr"), py::arg("annotation"))
+        .def("augment_variable_annotation", &protoboard<FieldT>::augment_variable_annotation, py::arg("pb_variable"), py::arg("postfix"))
+        .def("is_satisfied", &protoboard<FieldT>::is_satisfied)
+        // .def("dump_variables", &protoboard<FieldT>::dump_variables)
+        // invalid use of member function 
+        .def("num_constraints", &protoboard<FieldT>::num_constraints)
+        .def("num_inputs", &protoboard<FieldT>::num_inputs)
+        .def("num_variables", &protoboard<FieldT>::num_variables)
+        .def("set_input_sizes", &protoboard<FieldT>::set_input_sizes)
+        .def("full_variable_assignment", &protoboard<FieldT>::full_variable_assignment)
+        .def("primary_input", &protoboard<FieldT>::primary_input)
+        .def("auxiliary_input", &protoboard<FieldT>::auxiliary_input)
+        .def("get_constraint_system", &protoboard<FieldT>::get_constraint_system)
+}

--- a/src/PyZPK/reductions/bacs_to_r1cs.cpp
+++ b/src/PyZPK/reductions/bacs_to_r1cs.cpp
@@ -1,0 +1,26 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/reductions/bacs_to_r1cs/bacs_to_r1cs.hpp>
+using namespace std;
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for a BACS-to-R1CS reduction, that is, constructing
+// a R1CS ("Rank-1 Constraint System") from a BACS ("Bilinear Arithmetic Circuit Satisfiability").
+
+// Each bilinear gate gives rises to a corresponding R1CS constraint that enforces correct 
+// computation of the gate; also, each output gives rise to a corresponding R1CS constraint that enforces
+// that the output is zero.
+void init_reductions_bacs_to_r1cs(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    // Instance map for the BACS-to-R1CS reduction.
+    m.def("bacs_to_r1cs_instance_map", &bacs_to_r1cs_instance_map<FieldT>, py::arg("circuit"));
+
+    // Witness map for the BACS-to-R1CS reduction.
+    m.def("bacs_to_r1cs_witness_map", &bacs_to_r1cs_witness_map<FieldT>,
+          py::arg("circuit"), py::arg("primary_input"), py::arg("auxiliary_input"));
+}

--- a/test/test_gadgets.py
+++ b/test/test_gadgets.py
@@ -1,0 +1,31 @@
+import pytest
+import pyzpk
+
+def test_bacs():
+    new_num_constraints = 101
+    pb = pyzpk.protoboard()
+
+    # Test for pb_variable
+    res = pyzpk.pb_variable(0)
+    res.allocate(pb, "res")
+
+    # Test for pb_variable_array
+    A = pyzpk.pb_variable_array()
+    B = pyzpk.pb_variable_array()
+
+    A.allocate(pb, new_num_constraints, "A")
+    B.allocate(pb, new_num_constraints, "B")
+    assert len(A.get_vals(pb)) == 101
+    assert len(B.get_vals(pb)) == 101
+    assert A != B
+
+    # Test for pb_linear_combination
+    lc = pyzpk.linear_combination()
+    pb_lc = pyzpk.pb_linear_combination()
+    pb_lc.assign(pb,lc)
+    pb_lc.evaluate(pb)
+    assert pb_lc.is_constant() == True
+
+    # Test for pb_linear_combination_array
+    pb_A = pyzpk.pb_linear_combination_array()
+    pb_A.evaluate(pb)

--- a/test/test_relations.py
+++ b/test/test_relations.py
@@ -51,7 +51,6 @@ def test_sap(sap_degree, num_inputs, binary_input):
     t = pyzpk.Fp_model.random_element()
     d1 = pyzpk.Fp_model.random_element()
     d2 = pyzpk.Fp_model.random_element()
-    d3 = pyzpk.Fp_model.random_element()
 
 # Test for SSP
 @pytest.mark.parametrize("num_constraints, num_inputs, binary_input",


### PR DESCRIPTION
## Description

- Add Bindings for gadgetlib1 utils:
   - constraint_profiling,
   - gadget,
   - pb_variable (protoboard variables),
   - protoboard

- Add Bindings for bacs_to_r1cs reduction.

closes #10 #18 
## How has this been tested?
- This can be tested by running `pytest test` from the root folder.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
