### PR TITLE
Add Bindings for basic gadgets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/protoboard.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/pb_variable.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/protoboard.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/pb_variable.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/gadget_from_r1cs.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -30,6 +30,7 @@ void init_gadgetlib1_constraint_profiling(py::module &);
 void init_gadgetlib1_gadget(py::module &);
 void init_gadgetlib1_protoboard(py::module &);
 void init_gadgetlib1_pb_variable(py::module &);
+void init_gadgetlib1_gadgets_basic_gadgets(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -64,4 +65,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_gadget(m);
     init_gadgetlib1_protoboard(m);
     init_gadgetlib1_pb_variable(m);
+    init_gadgetlib1_gadgets_basic_gadgets(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -31,6 +31,7 @@ void init_gadgetlib1_gadget(py::module &);
 void init_gadgetlib1_protoboard(py::module &);
 void init_gadgetlib1_pb_variable(py::module &);
 void init_gadgetlib1_gadgets_basic_gadgets(py::module &);
+void init_gadgetlib1_gadgets_from_r1cs(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -66,4 +67,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_protoboard(m);
     init_gadgetlib1_pb_variable(m);
     init_gadgetlib1_gadgets_basic_gadgets(m);
+    init_gadgetlib1_gadgets_from_r1cs(m);
 }

--- a/src/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp
@@ -37,8 +37,39 @@ void declare_multipacking_gadget(py::module &m)
         .def("generate_r1cs_witness_from_bits", &multipacking_gadget<FieldT>::generate_r1cs_witness_from_bits);
 }
 
+void declare_field_vector_copy_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<field_vector_copy_gadget<FieldT>>(m, "field_vector_copy_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const pb_linear_combination<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &field_vector_copy_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &field_vector_copy_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void declare_bit_vector_copy_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<bit_vector_copy_gadget<FieldT>>(m, "bit_vector_copy_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const pb_linear_combination<FieldT> &,
+                      const size_t,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &bit_vector_copy_gadget<FieldT>::generate_r1cs_constraints, py::arg("enforce_source_bitness"), py::arg("enforce_target_bitness"))
+        .def("generate_r1cs_witness", &bit_vector_copy_gadget<FieldT>::generate_r1cs_witness);
+}
+
 void init_gadgetlib1_gadgets_basic_gadgets(py::module &m)
 {
     declare_packing_gadget(m);
     declare_multipacking_gadget(m);
+    declare_field_vector_copy_gadget(m);
+    declare_bit_vector_copy_gadget(m);
 }

--- a/src/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp
@@ -99,6 +99,19 @@ void declare_disjunction_gadget(py::module &m)
         .def("generate_r1cs_witness", &disjunction_gadget<FieldT>::generate_r1cs_witness);
 }
 
+void declare_conjunction_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<conjunction_gadget<FieldT>>(m, "conjunction_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &conjunction_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &conjunction_gadget<FieldT>::generate_r1cs_witness);
+}
+
 void init_gadgetlib1_gadgets_basic_gadgets(py::module &m)
 {
     declare_packing_gadget(m);
@@ -107,4 +120,5 @@ void init_gadgetlib1_gadgets_basic_gadgets(py::module &m)
     declare_bit_vector_copy_gadget(m);
     declare_dual_variable_gadget(m);
     declare_disjunction_gadget(m);
+    declare_conjunction_gadget(m);
 }

--- a/src/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp
@@ -1,0 +1,44 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/basic_gadgets.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+void declare_packing_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<packing_gadget<FieldT>>(m, "packing_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &packing_gadget<FieldT>::generate_r1cs_constraints, py::arg("enforce_bitness"))
+        .def("generate_r1cs_witness_from_packed", &packing_gadget<FieldT>::generate_r1cs_witness_from_packed)
+        .def("generate_r1cs_witness_from_bits", &packing_gadget<FieldT>::generate_r1cs_witness_from_bits);
+}
+
+void declare_multipacking_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<multipacking_gadget<FieldT>>(m, "multipacking_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const size_t,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &multipacking_gadget<FieldT>::generate_r1cs_constraints, py::arg("enforce_bitness"))
+        .def("generate_r1cs_witness_from_packed", &multipacking_gadget<FieldT>::generate_r1cs_witness_from_packed)
+        .def("generate_r1cs_witness_from_bits", &multipacking_gadget<FieldT>::generate_r1cs_witness_from_bits);
+}
+
+void init_gadgetlib1_gadgets_basic_gadgets(py::module &m)
+{
+    declare_packing_gadget(m);
+    declare_multipacking_gadget(m);
+}

--- a/src/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp
@@ -112,6 +112,51 @@ void declare_conjunction_gadget(py::module &m)
         .def("generate_r1cs_witness", &conjunction_gadget<FieldT>::generate_r1cs_witness);
 }
 
+void declare_comparison_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<comparison_gadget<FieldT>>(m, "comparison_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const size_t,
+                      const pb_linear_combination<FieldT> &,
+                      const pb_linear_combination<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &comparison_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &comparison_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void declare_inner_product_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<inner_product_gadget<FieldT>>(m, "inner_product_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &inner_product_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &inner_product_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void declare_loose_multiplexing_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<loose_multiplexing_gadget<FieldT>>(m, "loose_multiplexing_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &loose_multiplexing_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &loose_multiplexing_gadget<FieldT>::generate_r1cs_witness);
+}
+
 void init_gadgetlib1_gadgets_basic_gadgets(py::module &m)
 {
     declare_packing_gadget(m);
@@ -121,4 +166,7 @@ void init_gadgetlib1_gadgets_basic_gadgets(py::module &m)
     declare_dual_variable_gadget(m);
     declare_disjunction_gadget(m);
     declare_conjunction_gadget(m);
+    declare_comparison_gadget(m);
+    declare_inner_product_gadget(m);
+    declare_loose_multiplexing_gadget(m);
 }

--- a/src/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/basic_gadgets.cpp
@@ -66,10 +66,45 @@ void declare_bit_vector_copy_gadget(py::module &m)
         .def("generate_r1cs_witness", &bit_vector_copy_gadget<FieldT>::generate_r1cs_witness);
 }
 
+void declare_dual_variable_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<dual_variable_gadget<FieldT>>(m, "dual_variable_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const size_t,
+                      const std::string &>())
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const std::string &>())
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const size_t,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &dual_variable_gadget<FieldT>::generate_r1cs_constraints, py::arg("enforce_bitness"))
+        .def("generate_r1cs_witness_from_packed", &dual_variable_gadget<FieldT>::generate_r1cs_witness_from_packed)
+        .def("generate_r1cs_witness_from_bits", &dual_variable_gadget<FieldT>::generate_r1cs_witness_from_bits);
+}
+
+void declare_disjunction_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<disjunction_gadget<FieldT>>(m, "disjunction_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &disjunction_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &disjunction_gadget<FieldT>::generate_r1cs_witness);
+}
+
 void init_gadgetlib1_gadgets_basic_gadgets(py::module &m)
 {
     declare_packing_gadget(m);
     declare_multipacking_gadget(m);
     declare_field_vector_copy_gadget(m);
     declare_bit_vector_copy_gadget(m);
+    declare_dual_variable_gadget(m);
+    declare_disjunction_gadget(m);
 }

--- a/src/PyZPK/gadgetlib1/gadgets/gadget_from_r1cs.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/gadget_from_r1cs.cpp
@@ -1,0 +1,22 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/gadget_from_r1cs.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+void init_gadgetlib1_gadgets_from_r1cs(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<gadget_from_r1cs<FieldT>>(m, "gadget_from_r1cs")
+        .def(py::init<protoboard<FieldT> &,
+                     const std::vector<pb_variable_array<FieldT> > &,
+                     const r1cs_constraint_system<FieldT> &,
+                     const std::string &>())
+        .def("generate_r1cs_constraints", &gadget_from_r1cs<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &gadget_from_r1cs<FieldT>::generate_r1cs_witness, py::arg("primary_input"), py::arg("auxiliary_input"));
+}

--- a/test/test_gadgets.py
+++ b/test/test_gadgets.py
@@ -52,3 +52,23 @@ def test_disjunction_gadget():
     d.generate_r1cs_witness()
     assert pb.is_satisfied() == True
 
+def test_conjunction_gadget():
+
+    n = 10
+    pb = pyzpk.protoboard()
+
+    inputs = pyzpk.pb_variable_array()
+    inputs.allocate(pb, n, "inputs")
+
+    output = pyzpk.pb_variable(0)
+    output.allocate(pb, "output")
+
+    c = pyzpk.conjunction_gadget(pb, inputs, output, "c")
+    c.generate_r1cs_constraints()
+
+    for w in range(0, 1<<n):
+        for j in range(0, n):
+            inputs.get_vals(pb)[j] = pyzpk.Fp_model(pyzpk.bigint(1) if w&(1<<j) else pyzpk.bigint(0))
+
+    c.generate_r1cs_witness()
+    assert pb.is_satisfied() == True

--- a/test/test_gadgets.py
+++ b/test/test_gadgets.py
@@ -28,7 +28,7 @@ def test_bacs():
 
     # Test for pb_linear_combination_array
     pb_A = pyzpk.pb_linear_combination_array()
-    pb_A.evaluate(pb)
+    assert pb_A.evaluate(pb) == None
 
 def test_disjunction_gadget():
 
@@ -49,7 +49,7 @@ def test_disjunction_gadget():
         for j in range(0, n):
             inputs.get_vals(pb)[j] = pyzpk.Fp_model(pyzpk.bigint(1) if w&(1<<j) else pyzpk.bigint(0))
 
-    d.generate_r1cs_witness()
+    assert d.generate_r1cs_witness() == None
     assert pb.is_satisfied() == True
 
 def test_conjunction_gadget():
@@ -70,5 +70,31 @@ def test_conjunction_gadget():
         for j in range(0, n):
             inputs.get_vals(pb)[j] = pyzpk.Fp_model(pyzpk.bigint(1) if w&(1<<j) else pyzpk.bigint(0))
 
-    c.generate_r1cs_witness()
+    assert c.generate_r1cs_witness() == None
     assert pb.is_satisfied() == True
+
+def test_comparison_gadget():
+
+    n = 10
+    pb = pyzpk.protoboard()
+
+    A = pyzpk.pb_linear_combination()
+    B = pyzpk.pb_linear_combination()
+    less = pyzpk.pb_variable(0)
+    less_or_eq = pyzpk.pb_variable(0)
+    lc = pyzpk.linear_combination()
+
+    A.assign(pb, lc) 
+    B.assign(pb, lc)
+
+    assert A.evaluate(pb) == None
+    assert B.evaluate(pb) == None
+
+    less.allocate(pb, "less")
+    less_or_eq.allocate(pb, "less_or_eq")
+
+    cmp = pyzpk.comparison_gadget(pb, n, A, B, less, less_or_eq, "cmp")
+    cmp.generate_r1cs_constraints()
+    assert cmp.generate_r1cs_witness() == None
+    assert pb.is_satisfied() == True
+

--- a/test/test_gadgets.py
+++ b/test/test_gadgets.py
@@ -29,3 +29,26 @@ def test_bacs():
     # Test for pb_linear_combination_array
     pb_A = pyzpk.pb_linear_combination_array()
     pb_A.evaluate(pb)
+
+def test_disjunction_gadget():
+
+    # Testing disjunction_gadget on all n bit strings
+    n = 10
+    pb = pyzpk.protoboard()
+
+    inputs = pyzpk.pb_variable_array()
+    inputs.allocate(pb, n, "inputs")
+
+    output = pyzpk.pb_variable(0)
+    output.allocate(pb, "output")
+
+    d = pyzpk.disjunction_gadget(pb, inputs, output, "d")
+    d.generate_r1cs_constraints()
+
+    for w in range(0, 1<<n):
+        for j in range(0, n):
+            inputs.get_vals(pb)[j] = pyzpk.Fp_model(pyzpk.bigint(1) if w&(1<<j) else pyzpk.bigint(0))
+
+    d.generate_r1cs_witness()
+    assert pb.is_satisfied() == True
+


### PR DESCRIPTION
## Description
- This PR adds bindings for basic gadgets which includes Packing gadget, Copy gadget, dual variable gadget, disjunction, conjunction gadget, comparison gadget, inner product gadget, loose multiplexing gadget and gadgets from r1cs.
    
closes #19 

## How has this been tested?
- This can be tested by running `pytest test` from the root folder.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
