### PR TITLE
Add Bindings for curves gadget

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,8 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/cpu_checkers/tinyram/argument_decoder_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/cpu_checkers/tinyram/consistency_enforcer_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/cpu_checkers/tinyram/memory_masking_gadget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -42,6 +42,8 @@ void init_gadgetlib1_tinyram_alu_gadget(py::module &);
 void init_gadgetlib1_tinyram_argument_decoder_gadget(py::module &);
 void init_gadgetlib1_tinyram_consistency_enforcer_gadget(py::module &);
 void init_gadgetlib1_tinyram_memory_masking_gadget(py::module &);
+void init_gadgetlib1_curves_weierstrass_g1_gadget(py::module &);
+void init_gadgetlib1_curves_weierstrass_g2_gadget(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -88,4 +90,6 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_tinyram_argument_decoder_gadget(m);
     init_gadgetlib1_tinyram_consistency_enforcer_gadget(m);
     init_gadgetlib1_tinyram_memory_masking_gadget(m);
+    init_gadgetlib1_curves_weierstrass_g1_gadget(m);
+    init_gadgetlib1_curves_weierstrass_g2_gadget(m);
 }

--- a/src/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.cpp
@@ -1,0 +1,109 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_init.hpp>
+
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp>
+
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for G1 gadgets.
+// The gadgets verify curve arithmetic in G1 = E(F) where E/F: y^2 = x^3 + A * X + B
+// is an elliptic curve over F in short Weierstrass form.
+
+// Gadget that represents a G1 variable.
+void declare_G1_variable(py::module &m)
+{
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<G1_variable<ppT>, gadget<FieldT>>(m, "G1_variable")
+        .def(py::init<protoboard<FieldT> &,
+                const std::string &>())
+        .def(py::init<protoboard<FieldT> &,
+                const libff::G1<other_curve<ppT> > &,
+                const std::string &>())
+        .def("num_variables", &G1_variable<ppT>::num_variables)
+        .def("generate_r1cs_witness", &G1_variable<ppT>::generate_r1cs_witness);
+}
+
+// Gadget that creates constraints for the validity of a G1 variable.
+void declare_G1_checker_gadget(py::module &m)
+{
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<G1_checker_gadget<ppT>, gadget<FieldT>>(m, "G1_checker_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const G1_variable<ppT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &G1_checker_gadget<ppT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &G1_checker_gadget<ppT>::generate_r1cs_witness);
+}
+
+// Gadget that creates constraints for G1 addition.
+void declare_G1_add_gadget(py::module &m)
+{
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<G1_add_gadget<ppT>, gadget<FieldT>>(m, "G1_add_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const G1_variable<ppT> &,
+                      const G1_variable<ppT> &,
+                      const G1_variable<ppT> &,
+                      const std::string &>())
+        .def_readwrite("lambda", &G1_add_gadget<ppT>::lambda)
+        .def_readwrite("inv", &G1_add_gadget<ppT>::inv)
+        .def("generate_r1cs_constraints", &G1_add_gadget<ppT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &G1_add_gadget<ppT>::generate_r1cs_witness);
+}
+
+// Gadget that creates constraints for G1 doubling.
+void declare_G1_dbl_gadget(py::module &m)
+{
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<G1_dbl_gadget<ppT>, gadget<FieldT>>(m, "G1_dbl_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const G1_variable<ppT> &,
+                      const G1_variable<ppT> &,
+                      const std::string &>())
+        .def_readwrite("lambda", &G1_dbl_gadget<ppT>::lambda)
+        .def_readwrite("Xsquared", &G1_dbl_gadget<ppT>::Xsquared)
+        .def("generate_r1cs_constraints", &G1_dbl_gadget<ppT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &G1_dbl_gadget<ppT>::generate_r1cs_witness);
+}
+
+// Gadget that creates constraints for G1 multi-scalar multiplication.
+void declare_G1_multiscalar_mul_gadget(py::module &m)
+{
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<G1_multiscalar_mul_gadget<ppT>, gadget<FieldT>>(m, "G1_multiscalar_mul_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const G1_variable<ppT> &,
+                      const pb_variable_array<FieldT> &,
+                      const size_t,
+                      const std::vector<G1_variable<ppT>> &,
+                      const G1_variable<ppT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &G1_multiscalar_mul_gadget<ppT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &G1_multiscalar_mul_gadget<ppT>::generate_r1cs_witness);
+}
+
+void init_gadgetlib1_curves_weierstrass_g1_gadget(py::module &m)
+{
+    declare_G1_variable(m);
+    declare_G1_checker_gadget(m);
+    declare_G1_add_gadget(m);
+    declare_G1_dbl_gadget(m);
+    declare_G1_multiscalar_mul_gadget(m);
+}

--- a/src/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.cpp
@@ -1,0 +1,53 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_init.hpp>
+
+#include <libsnark/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/pairing/mnt_pairing_params.hpp>
+
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for G2 gadgets.
+// The gadgets verify curve arithmetic in G2 = E'(F) where E'/F^e: y^2 = x^3 + A' * X + B'
+// is an elliptic curve over F^e in short Weierstrass form.
+
+// Gadget that represents a G2 variable.
+void declare_G2_variable(py::module &m)
+{
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<G2_variable<ppT>, gadget<FieldT>>(m, "G2_variable")
+        .def(py::init<protoboard<FieldT> &,
+                const std::string &>())
+        .def(py::init<protoboard<FieldT> &,
+                const libff::G2<other_curve<ppT> > &,
+                const std::string &>())
+        .def("num_variables", &G2_variable<ppT>::num_variables)
+        .def("generate_r1cs_witness", &G2_variable<ppT>::generate_r1cs_witness);
+}
+
+// Gadget that creates constraints for the validity of a G2 variable.
+void declare_G2_checker_gadget(py::module &m)
+{
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<G2_checker_gadget<ppT>, gadget<FieldT>>(m, "G2_checker_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const G2_variable<ppT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &G2_checker_gadget<ppT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &G2_checker_gadget<ppT>::generate_r1cs_witness);
+}
+
+void init_gadgetlib1_curves_weierstrass_g2_gadget(py::module &m)
+{
+    declare_G2_variable(m);
+    declare_G2_checker_gadget(m);
+}


### PR DESCRIPTION
## Description
Add Bindings for curves gadgets which include bindings for Weierstrass g1 gadget and Weierstrass g2 gadget.

closes #21 

## How has this been tested?
- Curves are used along with verifiers, I will include test for curves in next PRs after we get bindings for verifiers.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
