### PR TITLE
Add Bindings for Hashes gadgets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/knapsack_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_aux.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_components.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/digest_selector_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/knapsack_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_aux.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_components.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/hash_io.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/digest_selector_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/knapsack_gadget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_aux.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/cpu_checkers/tinyram/memory_masking_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/hash_io.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g1_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/hash_io.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/digest_selector_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/curves/weierstrass_g2_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/hash_io.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/digest_selector_gadget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/knapsack_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -48,6 +48,7 @@ void init_gadgetlib1_hashes_hash_io(py::module &);
 void init_gadgetlib1_hashes_digest_selector_gadget(py::module &);
 void init_gadgetlib1_hashes_knapsack_gadget(py::module &);
 void init_gadgetlib1_hashes_sha256_aux_gadget(py::module &);
+void init_gadgetlib1_hashes_sha256_components(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -100,4 +101,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_hashes_digest_selector_gadget(m);
     init_gadgetlib1_hashes_knapsack_gadget(m);
     init_gadgetlib1_hashes_sha256_aux_gadget(m);
+    init_gadgetlib1_hashes_sha256_components(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -49,6 +49,7 @@ void init_gadgetlib1_hashes_digest_selector_gadget(py::module &);
 void init_gadgetlib1_hashes_knapsack_gadget(py::module &);
 void init_gadgetlib1_hashes_sha256_aux_gadget(py::module &);
 void init_gadgetlib1_hashes_sha256_components(py::module &);
+void init_gadgetlib1_hashes_sha256_gadget(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -102,4 +103,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_hashes_knapsack_gadget(m);
     init_gadgetlib1_hashes_sha256_aux_gadget(m);
     init_gadgetlib1_hashes_sha256_components(m);
+    init_gadgetlib1_hashes_sha256_gadget(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -44,6 +44,7 @@ void init_gadgetlib1_tinyram_consistency_enforcer_gadget(py::module &);
 void init_gadgetlib1_tinyram_memory_masking_gadget(py::module &);
 void init_gadgetlib1_curves_weierstrass_g1_gadget(py::module &);
 void init_gadgetlib1_curves_weierstrass_g2_gadget(py::module &);
+void init_gadgetlib1_hashes_hash_io(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -92,4 +93,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_tinyram_memory_masking_gadget(m);
     init_gadgetlib1_curves_weierstrass_g1_gadget(m);
     init_gadgetlib1_curves_weierstrass_g2_gadget(m);
+    init_gadgetlib1_hashes_hash_io(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -46,6 +46,7 @@ void init_gadgetlib1_curves_weierstrass_g1_gadget(py::module &);
 void init_gadgetlib1_curves_weierstrass_g2_gadget(py::module &);
 void init_gadgetlib1_hashes_hash_io(py::module &);
 void init_gadgetlib1_hashes_digest_selector_gadget(py::module &);
+void init_gadgetlib1_hashes_knapsack_gadget(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -96,4 +97,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_curves_weierstrass_g2_gadget(m);
     init_gadgetlib1_hashes_hash_io(m);
     init_gadgetlib1_hashes_digest_selector_gadget(m);
+    init_gadgetlib1_hashes_knapsack_gadget(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -47,6 +47,7 @@ void init_gadgetlib1_curves_weierstrass_g2_gadget(py::module &);
 void init_gadgetlib1_hashes_hash_io(py::module &);
 void init_gadgetlib1_hashes_digest_selector_gadget(py::module &);
 void init_gadgetlib1_hashes_knapsack_gadget(py::module &);
+void init_gadgetlib1_hashes_sha256_aux_gadget(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -98,4 +99,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_hashes_hash_io(m);
     init_gadgetlib1_hashes_digest_selector_gadget(m);
     init_gadgetlib1_hashes_knapsack_gadget(m);
+    init_gadgetlib1_hashes_sha256_aux_gadget(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -45,6 +45,7 @@ void init_gadgetlib1_tinyram_memory_masking_gadget(py::module &);
 void init_gadgetlib1_curves_weierstrass_g1_gadget(py::module &);
 void init_gadgetlib1_curves_weierstrass_g2_gadget(py::module &);
 void init_gadgetlib1_hashes_hash_io(py::module &);
+void init_gadgetlib1_hashes_digest_selector_gadget(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -94,4 +95,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_curves_weierstrass_g1_gadget(m);
     init_gadgetlib1_curves_weierstrass_g2_gadget(m);
     init_gadgetlib1_hashes_hash_io(m);
+    init_gadgetlib1_hashes_digest_selector_gadget(m);
 }

--- a/src/PyZPK/gadgetlib1/gadgets/hashes/digest_selector_gadget.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/hashes/digest_selector_gadget.cpp
@@ -1,0 +1,25 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/hashes/digest_selector_gadget.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+void init_gadgetlib1_hashes_digest_selector_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<digest_selector_gadget<FieldT>, gadget<FieldT>>(m, "digest_selector_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const size_t,
+                      const digest_variable<FieldT> &,
+                      const pb_linear_combination<FieldT> &,
+                      const digest_variable<FieldT> &,
+                      const digest_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &digest_selector_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &digest_selector_gadget<FieldT>::generate_r1cs_witness);
+}

--- a/src/PyZPK/gadgetlib1/gadgets/hashes/hash_io.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/hashes/hash_io.cpp
@@ -1,0 +1,52 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/hashes/hash_io.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+void declare_digest_variable(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<digest_variable<FieldT>, gadget<FieldT>>(m, "digest_variable")
+        .def(py::init<protoboard<FieldT> &,
+                      const size_t,
+                      const std::string &>())
+        .def(py::init<protoboard<FieldT> &,
+                      const size_t,
+                      const pb_variable_array<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &digest_variable<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &digest_variable<FieldT>::generate_r1cs_witness)
+        .def("get_digest", &digest_variable<FieldT>::get_digest);
+}
+
+void declare_block_variable(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<block_variable<FieldT>, gadget<FieldT>>(m, "block_variable")
+        .def(py::init<protoboard<FieldT> &,
+                      const size_t,
+                      const std::string &>())
+        .def(py::init<protoboard<FieldT> &,
+                      const std::vector<pb_variable_array<FieldT>> &,
+                      const std::string &>())
+        .def(py::init<protoboard<FieldT> &,
+                      const digest_variable<FieldT> &,
+                      const digest_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_witness", &block_variable<FieldT>::generate_r1cs_witness)
+        .def("get_block", &block_variable<FieldT>::get_block);
+}
+
+void init_gadgetlib1_hashes_hash_io(py::module &m)
+{
+    declare_digest_variable(m);
+    declare_block_variable(m);
+}

--- a/src/PyZPK/gadgetlib1/gadgets/hashes/knapsack_gadget.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/hashes/knapsack_gadget.cpp
@@ -1,0 +1,79 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//  The gadget checks the correct execution of a knapsack (modular subset-sum) over
+//  the field specified in the template parameter. With suitable choices of parameters
+//  such knapsacks are collision-resistant hashes (CRHs).
+//  Given two positive integers m (the input length) and d (the dimension),
+//  and a matrix M over the field F and of dimension dxm, the hash H_M maps {0,1}^m
+//  to F^d by sending x to M*x. Security of the function (very roughly) depends on
+//  d*log(|F|).
+//  Below, we give two different gadgets:
+//  - knapsack_CRH_with_field_out_gadget, which verifies H_M
+//  - knapsack_CRH_with_bit_out_gadget, which verifies H_M when its output is "expanded" to bits.
+//  In both cases, a method ("sample_randomness") allows to sample M.
+//  The parameter d (the dimension) is fixed at compile time in the struct
+//  knapsack_dimension below. The parameter m (the input length) can be chosen
+//  at run time (in either gadget).
+
+// Choice of dimension
+// The size of FieldT should be (approximately) at least 200 bits
+void declare_knapsack_dimension(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<knapsack_dimension<FieldT>>(m, "knapsack_dimension")
+        .attr("dimension") = 1;
+}
+
+// Knapsack with field output
+void declare_knapsack_CRH_with_field_out_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<knapsack_CRH_with_field_out_gadget<FieldT>, gadget<FieldT>>(m, "knapsack_CRH_with_field_out_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const size_t,
+                      const block_variable<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &knapsack_CRH_with_field_out_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &knapsack_CRH_with_field_out_gadget<FieldT>::generate_r1cs_witness)
+        .def_static("get_digest_len", &knapsack_CRH_with_field_out_gadget<FieldT>::get_digest_len)
+        .def_static("get_block_len", &knapsack_CRH_with_field_out_gadget<FieldT>::get_block_len)
+        .def_static("get_hash", &knapsack_CRH_with_field_out_gadget<FieldT>::get_hash)
+        .def_static("sample_randomness", &knapsack_CRH_with_field_out_gadget<FieldT>::sample_randomness);
+}
+
+// Knapsack with binary output
+void declare_knapsack_CRH_with_bit_out_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<knapsack_CRH_with_bit_out_gadget<FieldT>, gadget<FieldT>>(m, "knapsack_CRH_with_bit_out_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const size_t,
+                      const block_variable<FieldT> &,
+                      const digest_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &knapsack_CRH_with_bit_out_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &knapsack_CRH_with_bit_out_gadget<FieldT>::generate_r1cs_witness)
+        .def_static("get_digest_len", &knapsack_CRH_with_bit_out_gadget<FieldT>::get_digest_len)
+        .def_static("get_block_len", &knapsack_CRH_with_bit_out_gadget<FieldT>::get_block_len)
+        .def_static("get_hash", &knapsack_CRH_with_bit_out_gadget<FieldT>::get_hash)
+        .def_static("sample_randomness", &knapsack_CRH_with_bit_out_gadget<FieldT>::sample_randomness);
+}
+
+void init_gadgetlib1_hashes_knapsack_gadget(py::module &m)
+{
+    declare_knapsack_dimension(m);
+    declare_knapsack_CRH_with_field_out_gadget(m);
+    declare_knapsack_CRH_with_bit_out_gadget(m);
+}

--- a/src/PyZPK/gadgetlib1/gadgets/hashes/sha256_aux.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/hashes/sha256_aux.cpp
@@ -1,0 +1,114 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_aux.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for auxiliary gadgets for the SHA256 gadget.
+
+void declare_sha256_aux_lastbits_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<lastbits_gadget<FieldT>, gadget<FieldT>>(m, "lastbits_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const size_t,
+                      const pb_variable<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &lastbits_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &lastbits_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void declare_sha256_aux_XOR3_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<XOR3_gadget<FieldT>, gadget<FieldT>>(m, "XOR3_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_linear_combination<FieldT> &,
+                      const pb_linear_combination<FieldT> &,
+                      const pb_linear_combination<FieldT> &,
+                      const bool,
+                      const pb_linear_combination<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &XOR3_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &XOR3_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void declare_sha256_aux_small_sigma_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<small_sigma_gadget<FieldT>, gadget<FieldT>>(m, "small_sigma_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const size_t,
+                      const size_t,
+                      const size_t,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &small_sigma_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &small_sigma_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void declare_sha256_aux_big_sigma_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<big_sigma_gadget<FieldT>, gadget<FieldT>>(m, "big_sigma_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const size_t,
+                      const size_t,
+                      const size_t,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &big_sigma_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &big_sigma_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void declare_sha256_aux_choice_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<choice_gadget<FieldT>, gadget<FieldT>>(m, "choice_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                  const pb_linear_combination_array<FieldT> &,
+                  const pb_linear_combination_array<FieldT> &,
+                  const pb_linear_combination_array<FieldT> &,
+                  const pb_variable<FieldT> &,
+                  const std::string &>())
+        .def("generate_r1cs_constraints", &choice_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &choice_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void declare_sha256_aux_majority_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<majority_gadget<FieldT>, gadget<FieldT>>(m, "majority_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                  const pb_linear_combination_array<FieldT> &,
+                  const pb_linear_combination_array<FieldT> &,
+                  const pb_linear_combination_array<FieldT> &,
+                  const pb_variable<FieldT> &,
+                  const std::string &>())
+        .def("generate_r1cs_constraints", &majority_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &majority_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void init_gadgetlib1_hashes_sha256_aux_gadget(py::module &m)
+{
+    declare_sha256_aux_lastbits_gadget(m);
+    declare_sha256_aux_XOR3_gadget(m);
+    declare_sha256_aux_small_sigma_gadget(m);
+    declare_sha256_aux_big_sigma_gadget(m);
+    declare_sha256_aux_choice_gadget(m);
+    declare_sha256_aux_majority_gadget(m);
+}

--- a/src/PyZPK/gadgetlib1/gadgets/hashes/sha256_components.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/hashes/sha256_components.cpp
@@ -1,0 +1,58 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_components.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for gadgets for the SHA256 message schedule and round function.
+
+void declare_sha256_message_schedule_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    m.attr("SHA256_digest_size") = 256;
+    m.attr("SHA256_block_size") = 512;
+
+    m.def("SHA256_default_IV", &SHA256_default_IV<FieldT>);
+
+    py::class_<sha256_message_schedule_gadget<FieldT>, gadget<FieldT>>(m, "sha256_message_schedule_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &sha256_message_schedule_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &sha256_message_schedule_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void declare_sha256_round_function_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<sha256_round_function_gadget<FieldT>, gadget<FieldT>>(m, "sha256_round_function_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_variable<FieldT> &,
+                      const long &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &sha256_round_function_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &sha256_round_function_gadget<FieldT>::generate_r1cs_witness);
+}
+
+void init_gadgetlib1_hashes_sha256_components(py::module &m)
+{
+    declare_sha256_message_schedule_gadget(m);
+    declare_sha256_round_function_gadget(m);
+}

--- a/src/PyZPK/gadgetlib1/gadgets/hashes/sha256_components.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/hashes/sha256_components.cpp
@@ -17,8 +17,6 @@ void declare_sha256_message_schedule_gadget(py::module &m)
     m.attr("SHA256_digest_size") = 256;
     m.attr("SHA256_block_size") = 512;
 
-    m.def("SHA256_default_IV", &SHA256_default_IV<FieldT>);
-
     py::class_<sha256_message_schedule_gadget<FieldT>, gadget<FieldT>>(m, "sha256_message_schedule_gadget")
         .def(py::init<protoboard<FieldT> &,
                       const pb_variable_array<FieldT> &,

--- a/src/PyZPK/gadgetlib1/gadgets/hashes/sha256_gadget.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/hashes/sha256_gadget.cpp
@@ -1,0 +1,60 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for top-level SHA256 gadgets.
+
+// Gadget for the SHA256 compression function.
+void declare_sha256_compression_function_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<sha256_compression_function_gadget<FieldT>, gadget<FieldT>>(m, "sha256_compression_function_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const pb_linear_combination_array<FieldT> &,
+                      const pb_variable_array<FieldT> &,
+                      const digest_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &sha256_compression_function_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &sha256_compression_function_gadget<FieldT>::generate_r1cs_witness);
+}
+
+// Gadget for the SHA256 compression function, viewed as a 2-to-1 hash
+// function, and using the same initialization vector as in SHA256
+// specification. Thus, any collision for
+// sha256_two_to_one_hash_gadget trivially extends to a collision for
+// full SHA256 (by appending the same padding).
+void declare_sha256_two_to_one_hash_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+
+    py::class_<sha256_two_to_one_hash_gadget<FieldT>, gadget<FieldT>>(m, "sha256_two_to_one_hash_gadget")
+        .def(py::init<protoboard<FieldT> &,
+                      const digest_variable<FieldT> &,
+                      const digest_variable<FieldT> &,
+                      const digest_variable<FieldT> &,
+                      const std::string &>())
+        .def(py::init<protoboard<FieldT> &,
+                      const size_t,
+                      const block_variable<FieldT> &,
+                      const digest_variable<FieldT> &,
+                      const std::string &>())
+        .def("generate_r1cs_constraints", &sha256_two_to_one_hash_gadget<FieldT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &sha256_two_to_one_hash_gadget<FieldT>::generate_r1cs_witness)
+        .def_static("get_digest_len", &sha256_two_to_one_hash_gadget<FieldT>::get_digest_len)
+        .def_static("get_block_len", &sha256_two_to_one_hash_gadget<FieldT>::get_block_len)
+        .def_static("get_hash", &sha256_two_to_one_hash_gadget<FieldT>::get_hash)
+        .def_static("expected_constraints", &sha256_two_to_one_hash_gadget<FieldT>::expected_constraints);
+}
+
+void init_gadgetlib1_hashes_sha256_gadget(py::module &m)
+{
+    declare_sha256_compression_function_gadget(m);
+    declare_sha256_two_to_one_hash_gadget(m);
+}

--- a/test/test_gadgets.py
+++ b/test/test_gadgets.py
@@ -171,3 +171,20 @@ def test_tinyram_argument_decoder():
     assert pb.get_val(packed_desval).is_zero() == pyzpk.Fp_model(pyzpk.bigint(1005)).is_zero()
     assert pb.get_val(packed_desval).is_zero() == pyzpk.Fp_model(pyzpk.bigint(1007)).is_zero()
     assert pb.is_satisfied() == True
+    
+def test_knapsack_gadgets():
+    dimension = 1
+    input_bits = [1,1,0,0,1,0,1,0,0,1]
+    digest_bits = [1,1,1,1,0,0,1,0,1,0,0,0,1,1,0,0,1,1,1,0,0,0,1,0,1,1,1,0,0,1,1,1,1,0,0,0,0,1,0,1,0,0,1,1,1,1,1,1,1,0,0,1,1,0,1,0,1,1,0,1,1,0,1,0,1,1,1,1,0,1,0,0,0,0,0,1,0,1,1,0,0,0,1,0,1,0,0,0,1,0,1,1,0,0,1,1,1,1,0,0,1,1,0,0,1,0,0,0,0,0,1,1,1,0,1,1,1,0,0,0,1,0,1,0,1,1,0,0,0,1,1,1,0,0,1,1,0,1,1,0,1,0,1,1,0,1,1,0,0,0,0,1,1,1,1,1,1,1,0,1,0,1,0,0,0,0,0,1,1,1,1,0,0,0,1,0,0,1,1,1,0,0,0,1,1,1,1,1,1,0,1,0,1,0,0,1,1,0,0,1,1,1,1,0,0,0,1,0,0,0,0,1,0,1,0,1,0,0,1,0,0,1,1,0,1,1,1,1,0,0,1,1,0,0,1,1,0,1,0,1,1,0,1,1,1,0,0,1,1,1,1,1,0,1,0,0,0,1,0,0,1,1,1,0,1,1,0,1,1,0,0,1,1,0,0,0,0,0,1,0,1,1,0,0,0,0,1,1,1,1,0,1,0,0,0,0,0,0]
+
+    assert pyzpk.knapsack_dimension.dimension == dimension
+
+    pb = pyzpk.protoboard()
+
+    input_block = pyzpk.block_variable(pb, len(input_bits) , "input_block")
+    digest_len = pyzpk.knapsack_CRH_with_bit_out_gadget.get_digest_len()
+    output_digest = pyzpk.digest_variable(pb, digest_len, "output_digest")
+    input_block.generate_r1cs_witness(input_bits);
+
+    assert pb.is_satisfied() == True
+    

--- a/test/test_gadgets.py
+++ b/test/test_gadgets.py
@@ -188,3 +188,22 @@ def test_knapsack_gadgets():
 
     assert pb.is_satisfied() == True
     
+def test_sha256_gadgets():
+    pb = pyzpk.protoboard()
+    left = pyzpk.digest_variable(pb,pyzpk.SHA256_digest_size, "left")
+    right = pyzpk.digest_variable(pb,pyzpk.SHA256_digest_size, "right")
+    output = pyzpk.digest_variable(pb,pyzpk.SHA256_digest_size, "output")
+    f = pyzpk.sha256_two_to_one_hash_gadget(pb, left, right, output, "f")
+    f.generate_r1cs_constraints(True)
+
+    # Number of constraints for sha256_two_to_one_hash_gadget
+    assert pb.num_constraints() == 27280
+
+    left_bv = [0x426bc2d8, 0x4dc86782, 0x81e8957a, 0x409ec148, 0xe6cffbe8, 0xafe6ba4f, 0x9c6f1978, 0xdd7af7e9]
+    right_bv = [0x038cce42, 0xabd366b8, 0x3ede7e00, 0x9130de53, 0x72cdf73d, 0xee825114, 0x8cb48d1b, 0x9af68ad0]
+    hash_bv = [0xeffd0b7f, 0x1ccba116, 0x2ee816f7, 0x31c62b48, 0x59305141, 0x990e5c0a, 0xce40d33d, 0x0b1167d1]
+    left.generate_r1cs_witness(left_bv)
+    right.generate_r1cs_witness(right_bv)
+    f.generate_r1cs_witness()
+    output.generate_r1cs_witness(hash_bv)
+    assert pb.is_satisfied() == True


### PR DESCRIPTION
## Description
Add bindings for hashes gadgets which include knapsack and sha256 gadgets.

closes #23 

## How has this been tested?
- This can be tested by running `pytest test` from the root folder.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
