### PR TITLE
Add Bindings for merkle tree gadgets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,8 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_components.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_aux.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_components.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/hashes/sha256_gadget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -50,6 +50,7 @@ void init_gadgetlib1_hashes_knapsack_gadget(py::module &);
 void init_gadgetlib1_hashes_sha256_aux_gadget(py::module &);
 void init_gadgetlib1_hashes_sha256_components(py::module &);
 void init_gadgetlib1_hashes_sha256_gadget(py::module &);
+void init_merkle_authentication_path_variable(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -104,4 +105,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_hashes_sha256_aux_gadget(m);
     init_gadgetlib1_hashes_sha256_components(m);
     init_gadgetlib1_hashes_sha256_gadget(m);
+    init_merkle_authentication_path_variable(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -51,6 +51,8 @@ void init_gadgetlib1_hashes_sha256_aux_gadget(py::module &);
 void init_gadgetlib1_hashes_sha256_components(py::module &);
 void init_gadgetlib1_hashes_sha256_gadget(py::module &);
 void init_merkle_authentication_path_variable(py::module &);
+void init_merkle_tree_check_read_gadget(py::module &);
+void init_merkle_tree_check_update_gadget(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -106,4 +108,6 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib1_hashes_sha256_components(m);
     init_gadgetlib1_hashes_sha256_gadget(m);
     init_merkle_authentication_path_variable(m);
+    init_merkle_tree_check_read_gadget(m);
+    init_merkle_tree_check_update_gadget(m);
 }

--- a/src/PyZPK/gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.cpp
@@ -1,0 +1,26 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.hpp>
+#include <libsnark/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+void init_merkle_authentication_path_variable(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+    using HashT =  knapsack_CRH_with_field_out_gadget<FieldT>;
+
+    py::class_<merkle_authentication_path_variable<FieldT, HashT>, gadget<FieldT>>(m, "merkle_authentication_path_variable")
+        .def(py::init<protoboard<FieldT> &,
+                      const size_t,
+                      const std::string &>())
+
+        .def_readonly("tree_depth", &merkle_authentication_path_variable<FieldT, HashT>::tree_depth)
+        .def("generate_r1cs_constraints", &merkle_authentication_path_variable<FieldT, HashT>::generate_r1cs_constraints)
+        .def("generate_r1cs_witness", &merkle_authentication_path_variable<FieldT, HashT>::generate_r1cs_witness)
+        .def("get_authentication_path", &merkle_authentication_path_variable<FieldT, HashT>::get_authentication_path);
+}

--- a/src/PyZPK/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.cpp
@@ -1,0 +1,27 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for the Merkle tree check read gadget.
+// The gadget checks the following: given a root R, address A, value V, and
+// authentication path P, check that P is a valid authentication path for the
+// value V as the A-th leaf in a Merkle tree with root R.
+
+void init_merkle_tree_check_read_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+    using HashT = knapsack_CRH_with_field_out_gadget<FieldT>;
+
+    py::class_<merkle_tree_check_read_gadget<FieldT, HashT>, gadget<FieldT>>(m, "merkle_tree_check_read_gadget")
+        .def_readonly("digest_size", &merkle_tree_check_read_gadget<FieldT, HashT>::digest_size)
+        .def_readonly("tree_depth", &merkle_tree_check_read_gadget<FieldT, HashT>::tree_depth)
+        .def("generate_r1cs_witness", &merkle_tree_check_read_gadget<FieldT, HashT>::generate_r1cs_witness)
+        .def_static("root_size_in_bits", &merkle_tree_check_read_gadget<FieldT, HashT>::root_size_in_bits);
+}

--- a/src/PyZPK/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.cpp
+++ b/src/PyZPK/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.cpp
@@ -1,0 +1,28 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_update_gadget.hpp>
+#include <libsnark/gadgetlib1/gadgets/hashes/knapsack/knapsack_gadget.hpp>
+
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for the Merkle tree check update gadget.
+//  The gadget checks the following: given two roots R1 and R2, address A, two
+//  values V1 and V2, and authentication path P, check that
+//  - P is a valid authentication path for the value V1 as the A-th leaf in a Merkle tree with root R1, and
+//  - P is a valid authentication path for the value V2 as the A-th leaf in a Merkle tree with root R2.
+
+void init_merkle_tree_check_update_gadget(py::module &m)
+{
+    using FieldT = Fp_model<5l, libff::mnt46_modulus_B>;
+    using HashT = knapsack_CRH_with_field_out_gadget<FieldT>;
+
+    py::class_<merkle_tree_check_update_gadget<FieldT, HashT>, gadget<FieldT>>(m, "merkle_tree_check_update_gadget")
+        .def_readonly("digest_size", &merkle_tree_check_update_gadget<FieldT, HashT>::digest_size)
+        .def_readonly("tree_depth", &merkle_tree_check_update_gadget<FieldT, HashT>::tree_depth)
+        .def("generate_r1cs_witness", &merkle_tree_check_update_gadget<FieldT, HashT>::generate_r1cs_witness)
+        .def_static("root_size_in_bits", &merkle_tree_check_update_gadget<FieldT, HashT>::root_size_in_bits);
+}

--- a/src/PyZPK/utils/Fp_model.cpp
+++ b/src/PyZPK/utils/Fp_model.cpp
@@ -70,6 +70,7 @@ void init_utils_Fp_model(py::module &m)
         .def("is_zero", &Fp_model<5l, libff::mnt46_modulus_B>::is_zero)
         .def_static("one", &Fp_model<5l, libff::mnt46_modulus_B>::one)
         .def_static("zero", &Fp_model<5l, libff::mnt46_modulus_B>::zero)
+        .def("as_ulong", &Fp_model<5l, libff::mnt46_modulus_B>::as_ulong)
         .def(py::self * py::self)
         .def(py::self *= py::self)
         .def(-py::self);  


### PR DESCRIPTION
## Description
This PR adds bindings for Merkle tree gadgets.

closes #24 
## How has this been tested?
- This can be tested by running `pytest test` from the root folder.


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
