### PR TITLE
Add Bindings for r1cs ppzksnark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,8 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib2/integration.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib2/gadget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/gadgetlib2/adapters.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/knowledge_commitment/knowledge_commitment.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/knowledge_commitment/kc_multiexp.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/compliance_predicate.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/tally_cp.cpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/tally_cp.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_pcd_params.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/r1cs_ppzksnark/run_r1cs_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,7 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/cp_handler.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/compliance_predicate/tally_cp.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_pcd_params.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -78,6 +78,7 @@ void init_zk_proof_systems_pcd_r1cs_pcd_cp_handler(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_pcd_params(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_tally_cp(py::module &);
 void init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_r1cs_ppzksnark(py::module &);
+void init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_run_r1cs_ppzksnark(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -160,4 +161,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_zk_proof_systems_pcd_r1cs_pcd_r1cs_pcd_params(m);
     init_zk_proof_systems_pcd_r1cs_pcd_tally_cp(m);
     init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_r1cs_ppzksnark(m);
+    init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_run_r1cs_ppzksnark(m);
 }

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -71,6 +71,8 @@ void init_gadgetlib2_Protoboard(py::module &);
 void init_gadgetlib2_integration(py::module &);
 void init_gadgetlib2_gadget(py::module &);
 void init_gadgetlib2_adapters(py::module &);
+void init_knowledge_commitment_knowledge_commitment(py::module &);
+void init_knowledge_commitment_kc_multiexp(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_compliance_predicate(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_cp_handler(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_pcd_params(py::module &);
@@ -151,6 +153,8 @@ PYBIND11_MODULE(pyzpk, m)
     init_gadgetlib2_integration(m);
     init_gadgetlib2_gadget(m);
     init_gadgetlib2_adapters(m);
+    init_knowledge_commitment_knowledge_commitment(m);
+    init_knowledge_commitment_kc_multiexp(m);
     init_zk_proof_systems_pcd_r1cs_pcd_compliance_predicate(m);
     init_zk_proof_systems_pcd_r1cs_pcd_cp_handler(m);
     init_zk_proof_systems_pcd_r1cs_pcd_r1cs_pcd_params(m);

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -75,6 +75,7 @@ void init_zk_proof_systems_pcd_r1cs_pcd_compliance_predicate(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_cp_handler(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_pcd_params(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_tally_cp(py::module &);
+void init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_r1cs_ppzksnark(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -154,4 +155,5 @@ PYBIND11_MODULE(pyzpk, m)
     init_zk_proof_systems_pcd_r1cs_pcd_cp_handler(m);
     init_zk_proof_systems_pcd_r1cs_pcd_r1cs_pcd_params(m);
     init_zk_proof_systems_pcd_r1cs_pcd_tally_cp(m);
+    init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_r1cs_ppzksnark(m);
 }

--- a/src/PyZPK/knowledge_commitment/kc_multiexp.cpp
+++ b/src/PyZPK/knowledge_commitment/kc_multiexp.cpp
@@ -1,0 +1,29 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+#include <libsnark/knowledge_commitment/kc_multiexp.hpp>
+#include <libsnark/knowledge_commitment/kc_multiexp.tcc>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//   Split out from multiexp to prevent cyclical dependencies. I.e. previously multiexp dependend on
+//   knowledge_commitment, which dependend on sparse_vector, which depended on multiexp (to do accumulate).
+//   Will probably go away in more general exp refactoring.
+
+void init_knowledge_commitment_kc_multiexp(py::module &m)
+{
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+    using T1 = libff::G1<ppT>;
+    using T2 = libff::G1<ppT>;
+
+    m.def("opt_window_wnaf_exp", &opt_window_wnaf_exp<T1, T2, 5l>);
+    m.def("kc_multi_exp_with_mixed_addition", &kc_multi_exp_with_mixed_addition<T1, T2, FieldT, libff::multi_exp_method_bos_coster>);
+    m.def("kc_batch_exp", &kc_batch_exp<T1, T2, FieldT>);
+    m.def("kc_batch_exp_internal", &kc_batch_exp_internal<T1, T2, FieldT>);
+}

--- a/src/PyZPK/knowledge_commitment/knowledge_commitment.cpp
+++ b/src/PyZPK/knowledge_commitment/knowledge_commitment.cpp
@@ -1,0 +1,62 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
+#include <libff/common/profiling.hpp>
+#include <libff/common/utils.hpp>
+#include <libsnark/knowledge_commitment/knowledge_commitment.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//   A knowledge commitment is a pair (g,h) where g is in T1 and h in T2,
+//   and T1 and T2 are groups (written additively).
+//   Such pairs form a group by defining:
+//   - "zero" = (0,0)
+//   - "one" = (1,1)
+//   - a * (g,h) + b * (g',h') := ( a * g + b * g', a * h + b * h').
+
+void init_knowledge_commitment_knowledge_commitment(py::module &m)
+{
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+    using T1 = libff::G1<ppT>;
+    using T2 = libff::G1<ppT>;
+
+    py::class_<knowledge_commitment<T1, T2>>(m, "knowledge_commitment")
+        .def(py::init<>())
+        .def(py::init<const knowledge_commitment<T1, T2> &>())
+        .def(py::init<const T1 &, const T2 &>())
+        .def_readwrite("g", &knowledge_commitment<T1, T2>::g)
+        .def_readwrite("h", &knowledge_commitment<T1, T2>::h)
+        .def("mixed_add", &knowledge_commitment<T1, T2>::mixed_add)
+        .def("dbl", &knowledge_commitment<T1, T2>::dbl)
+        .def("to_special", &knowledge_commitment<T1, T2>::to_special)
+        .def("is_zero", &knowledge_commitment<T1, T2>::is_zero)
+        .def("print", &knowledge_commitment<T1, T2>::print)
+        .def_static("size_in_bits", &knowledge_commitment<T1, T2>::size_in_bits)
+        .def_static("zero", &knowledge_commitment<T1, T2>::zero)
+        .def_static("one", &knowledge_commitment<T1, T2>::one)
+        .def_static("size_in_bits", &knowledge_commitment<T1, T2>::size_in_bits)
+        .def_static("batch_to_special_all_non_zeros", &knowledge_commitment<T1, T2>::batch_to_special_all_non_zeros)
+        .def(py::self + py::self)
+        .def(bigint<5l>() * py::self)
+        .def(FieldT() * py::self)
+        .def(
+            "__eq__", [](knowledge_commitment<T1, T2> const &self, knowledge_commitment<T1, T2> const &other) { return self == other; }, py::is_operator())
+        .def(
+            "__ne__", [](knowledge_commitment<T1, T2> const &self, knowledge_commitment<T1, T2> const &other) { return self != other; }, py::is_operator())
+        .def("__ostr__", [](knowledge_commitment<T1, T2> const &self) {
+            std::ostringstream os;
+            os << self.g << OUTPUT_SEPARATOR << self.h;
+            return os;
+        })
+        .def("__istr__", [](knowledge_commitment<T1, T2> &self) {
+            std::istringstream in;
+            in >> self.g;
+            libff::consume_OUTPUT_SEPARATOR(in);
+            in >> self.h;
+            return in;
+        });
+}

--- a/src/PyZPK/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.cpp
@@ -1,0 +1,267 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//  Interfaces for a ppzkSNARK for R1CS.
+//  This includes:
+//  - class for proving key
+//  - class for verification key
+//  - class for processed verification key
+//  - class for key pair (proving key & verification key)
+//  - class for proof
+//  - generator algorithm
+//  - prover algorithm
+//  - verifier algorithm (with strong or weak input consistency)
+//  - online verifier algorithm (with strong or weak input consistency)
+
+void declare_r1cs_ppzksnark_proving_key(py::module &m)
+{
+    // A proving key for the R1CS ppzkSNARK.
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<r1cs_ppzksnark_proving_key<ppT>>(m, "r1cs_ppzksnark_proving_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_ppzksnark_proving_key<ppT> &>())
+        .def_readwrite("A_query", &r1cs_ppzksnark_proving_key<ppT>::A_query)
+        .def_readwrite("B_query", &r1cs_ppzksnark_proving_key<ppT>::B_query)
+        .def_readwrite("C_query", &r1cs_ppzksnark_proving_key<ppT>::C_query)
+        .def_readwrite("H_query", &r1cs_ppzksnark_proving_key<ppT>::H_query)
+        .def_readwrite("K_query", &r1cs_ppzksnark_proving_key<ppT>::K_query)
+        .def_readwrite("constraint_system", &r1cs_ppzksnark_proving_key<ppT>::constraint_system)
+        .def("G1_size", &r1cs_ppzksnark_proving_key<ppT>::G1_size)
+        .def("G2_size", &r1cs_ppzksnark_proving_key<ppT>::G2_size)
+        .def("G1_sparse_size", &r1cs_ppzksnark_proving_key<ppT>::G1_sparse_size)
+        .def("G2_sparse_size", &r1cs_ppzksnark_proving_key<ppT>::G2_sparse_size)
+        .def("size_in_bits", &r1cs_ppzksnark_proving_key<ppT>::size_in_bits)
+        .def("print_size", &r1cs_ppzksnark_proving_key<ppT>::print_size)
+        .def(
+            "__eq__", [](r1cs_ppzksnark_proving_key<ppT> const &self, r1cs_ppzksnark_proving_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_ppzksnark_proving_key<ppT> const &self) {
+            std::ostringstream os;
+            os << self.A_query;
+            os << self.B_query;
+            os << self.C_query;
+            os << self.H_query;
+            os << self.K_query;
+            os << self.constraint_system;
+            return os;
+        })
+        .def("__istr__", [](r1cs_ppzksnark_proving_key<ppT> &self) {
+            std::istringstream in;
+            in >> self.A_query;
+            in >> self.B_query;
+            in >> self.C_query;
+            in >> self.H_query;
+            in >> self.K_query;
+            in >> self.constraint_system;
+            return in;
+        });
+}
+
+void declare_r1cs_ppzksnark_verification_key(py::module &m)
+{
+    // A verification key for the R1CS ppzkSNARK.
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<r1cs_ppzksnark_verification_key<ppT>>(m, "r1cs_ppzksnark_verification_key")
+        .def(py::init<>())
+        .def(py::init<const libff::G2<ppT> &,
+                      const libff::G1<ppT> &,
+                      const libff::G2<ppT> &,
+                      const libff::G2<ppT> &,
+                      const libff::G1<ppT> &,
+                      const libff::G2<ppT> &,
+                      const libff::G2<ppT> &,
+                      const accumulation_vector<libff::G1<ppT>> &>())
+        .def_readwrite("alphaA_g2", &r1cs_ppzksnark_verification_key<ppT>::alphaA_g2)
+        .def_readwrite("alphaB_g1", &r1cs_ppzksnark_verification_key<ppT>::alphaB_g1)
+        .def_readwrite("alphaC_g2", &r1cs_ppzksnark_verification_key<ppT>::alphaC_g2)
+        .def_readwrite("gamma_g2", &r1cs_ppzksnark_verification_key<ppT>::gamma_g2)
+        .def_readwrite("gamma_beta_g1", &r1cs_ppzksnark_verification_key<ppT>::gamma_beta_g1)
+        .def_readwrite("gamma_beta_g2", &r1cs_ppzksnark_verification_key<ppT>::gamma_beta_g2)
+        .def_readwrite("rC_Z_g2", &r1cs_ppzksnark_verification_key<ppT>::rC_Z_g2)
+        .def("G1_size", &r1cs_ppzksnark_verification_key<ppT>::G1_size)
+        .def("G2_size", &r1cs_ppzksnark_verification_key<ppT>::G2_size)
+        .def("size_in_bits", &r1cs_ppzksnark_verification_key<ppT>::size_in_bits)
+        .def("print_size", &r1cs_ppzksnark_verification_key<ppT>::print_size)
+        .def_static("dummy_verification_key", &r1cs_ppzksnark_verification_key<ppT>::dummy_verification_key)
+        .def(
+            "__eq__", [](r1cs_ppzksnark_verification_key<ppT> const &self, r1cs_ppzksnark_verification_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_ppzksnark_verification_key<ppT> const &self) {
+            std::ostringstream os;
+            os << self.alphaA_g2 << OUTPUT_NEWLINE;
+            os << self.alphaB_g1 << OUTPUT_NEWLINE;
+            os << self.alphaC_g2 << OUTPUT_NEWLINE;
+            os << self.gamma_g2 << OUTPUT_NEWLINE;
+            os << self.gamma_beta_g1 << OUTPUT_NEWLINE;
+            os << self.gamma_beta_g2 << OUTPUT_NEWLINE;
+            os << self.rC_Z_g2 << OUTPUT_NEWLINE;
+            os << self.encoded_IC_query << OUTPUT_NEWLINE;
+            return os;
+        })
+        .def("__istr__", [](r1cs_ppzksnark_verification_key<ppT> &self) {
+            std::istringstream in;
+            in >> self.alphaA_g2;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.alphaB_g1;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.alphaC_g2;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.gamma_g2;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.gamma_beta_g1;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.gamma_beta_g2;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.rC_Z_g2;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.encoded_IC_query;
+            libff::consume_OUTPUT_NEWLINE(in);
+            return in;
+        });
+}
+
+void declare_r1cs_ppzksnark_processed_verification_key(py::module &m)
+{
+    // A verification key for the R1CS ppzkSNARK.
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<r1cs_ppzksnark_processed_verification_key<ppT>>(m, "r1cs_ppzksnark_processed_verification_key")
+        .def(py::init<>())
+        .def_readwrite("pp_G2_one_precomp", &r1cs_ppzksnark_processed_verification_key<ppT>::pp_G2_one_precomp)
+        .def_readwrite("vk_alphaA_g2_precomp", &r1cs_ppzksnark_processed_verification_key<ppT>::vk_alphaA_g2_precomp)
+        .def_readwrite("vk_alphaB_g1_precomp", &r1cs_ppzksnark_processed_verification_key<ppT>::vk_alphaB_g1_precomp)
+        .def_readwrite("vk_alphaC_g2_precomp", &r1cs_ppzksnark_processed_verification_key<ppT>::vk_alphaC_g2_precomp)
+        .def_readwrite("vk_rC_Z_g2_precomp", &r1cs_ppzksnark_processed_verification_key<ppT>::vk_rC_Z_g2_precomp)
+        .def_readwrite("vk_gamma_g2_precomp", &r1cs_ppzksnark_processed_verification_key<ppT>::vk_gamma_g2_precomp)
+        .def_readwrite("vk_gamma_beta_g1_precomp", &r1cs_ppzksnark_processed_verification_key<ppT>::vk_gamma_beta_g1_precomp)
+        .def_readwrite("vk_gamma_beta_g2_precomp", &r1cs_ppzksnark_processed_verification_key<ppT>::vk_gamma_beta_g2_precomp)
+        .def_readwrite("encoded_IC_query", &r1cs_ppzksnark_processed_verification_key<ppT>::encoded_IC_query)
+        .def(
+            "__eq__", [](r1cs_ppzksnark_processed_verification_key<ppT> const &self, r1cs_ppzksnark_processed_verification_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_ppzksnark_processed_verification_key<ppT> const &self) {
+            std::ostringstream os;
+            os << self.pp_G2_one_precomp << OUTPUT_NEWLINE;
+            os << self.vk_alphaA_g2_precomp << OUTPUT_NEWLINE;
+            os << self.vk_alphaB_g1_precomp << OUTPUT_NEWLINE;
+            os << self.vk_alphaC_g2_precomp << OUTPUT_NEWLINE;
+            os << self.vk_rC_Z_g2_precomp << OUTPUT_NEWLINE;
+            os << self.vk_gamma_g2_precomp << OUTPUT_NEWLINE;
+            os << self.vk_gamma_beta_g1_precomp << OUTPUT_NEWLINE;
+            os << self.vk_gamma_beta_g2_precomp << OUTPUT_NEWLINE;
+            os << self.encoded_IC_query << OUTPUT_NEWLINE;
+            return os;
+        })
+        .def("__istr__", [](r1cs_ppzksnark_processed_verification_key<ppT> &self) {
+            std::istringstream in;
+            in >> self.pp_G2_one_precomp;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.vk_alphaA_g2_precomp;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.vk_alphaB_g1_precomp;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.vk_alphaC_g2_precomp;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.vk_rC_Z_g2_precomp;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.vk_gamma_g2_precomp;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.vk_gamma_beta_g1_precomp;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.vk_gamma_beta_g2_precomp;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.encoded_IC_query;
+            libff::consume_OUTPUT_NEWLINE(in);
+            return in;
+        });
+}
+
+void declare_r1cs_ppzksnark_keypair(py::module &m)
+{
+    // A key pair for the R1CS ppzkSNARK, which consists of a proving key and a verification key.
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<r1cs_ppzksnark_keypair<ppT>>(m, "r1cs_ppzksnark_keypair")
+        .def(py::init<>())
+        .def(py::init<const r1cs_ppzksnark_keypair<ppT> &>())
+        .def_readwrite("pk", &r1cs_ppzksnark_keypair<ppT>::pk)
+        .def_readwrite("vk", &r1cs_ppzksnark_keypair<ppT>::vk);
+}
+
+void declare_r1cs_ppzksnark_proof(py::module &m)
+{
+    // A verification key for the R1CS ppzkSNARK.
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<r1cs_ppzksnark_proof<ppT>>(m, "r1cs_ppzksnark_proof")
+        .def(py::init<>())
+        .def_readwrite("g_A", &r1cs_ppzksnark_proof<ppT>::g_A)
+        .def_readwrite("g_B", &r1cs_ppzksnark_proof<ppT>::g_B)
+        .def_readwrite("g_C", &r1cs_ppzksnark_proof<ppT>::g_C)
+        .def_readwrite("g_H", &r1cs_ppzksnark_proof<ppT>::g_H)
+        .def_readwrite("g_K", &r1cs_ppzksnark_proof<ppT>::g_K)
+        .def("G1_size", &r1cs_ppzksnark_proof<ppT>::G1_size)
+        .def("G2_size", &r1cs_ppzksnark_proof<ppT>::G2_size)
+        .def("size_in_bits", &r1cs_ppzksnark_proof<ppT>::size_in_bits)
+        .def("print_size", &r1cs_ppzksnark_proof<ppT>::print_size)
+        .def("is_well_formed", &r1cs_ppzksnark_proof<ppT>::is_well_formed)
+        .def(
+            "__eq__", [](r1cs_ppzksnark_proof<ppT> const &self, r1cs_ppzksnark_proof<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_ppzksnark_proof<ppT> const &self) {
+            std::ostringstream os;
+            os << self.g_A << OUTPUT_NEWLINE;
+            os << self.g_B << OUTPUT_NEWLINE;
+            os << self.g_C << OUTPUT_NEWLINE;
+            os << self.g_H << OUTPUT_NEWLINE;
+            os << self.g_K << OUTPUT_NEWLINE;
+            return os;
+        })
+        .def("__istr__", [](r1cs_ppzksnark_proof<ppT> &self) {
+            std::istringstream in;
+            in >> self.g_A;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.g_B;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.g_C;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.g_H;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> self.g_K;
+            libff::consume_OUTPUT_NEWLINE(in);
+            return in;
+        });
+}
+
+void declare_Main_algorithms(py::module &m)
+{
+    using ppT = mnt6_pp;
+
+    m.def("r1cs_ppzksnark_generator", &r1cs_ppzksnark_generator<ppT>, "A generator algorithm for the R1CS ppzkSNARK Given a R1CS constraint system CS, this algorithm produces proving and verification keys for C");
+    m.def("r1cs_ppzksnark_prover", &r1cs_ppzksnark_prover<ppT>, "A prover algorithm for the R1CS ppzkSNARK.");
+    m.def("r1cs_ppzksnark_verifier_weak_IC", &r1cs_ppzksnark_verifier_weak_IC<ppT>, "A verifier algorithm for the R1CS ppzkSNARK");
+    m.def("r1cs_ppzksnark_verifier_strong_IC", &r1cs_ppzksnark_verifier_strong_IC<ppT>, "A verifier algorithm for the R1CS ppzkSNARK");
+    m.def("r1cs_ppzksnark_verifier_process_vk", &r1cs_ppzksnark_verifier_process_vk<ppT>, "Convert a (non-processed) verification key into a processed verification key.");
+    m.def("r1cs_ppzksnark_online_verifier_weak_IC", &r1cs_ppzksnark_online_verifier_weak_IC<ppT>, "A verifier algorithm for the R1CS ppzkSNARK");
+    m.def("r1cs_ppzksnark_online_verifier_strong_IC", &r1cs_ppzksnark_online_verifier_strong_IC<ppT>, "A verifier algorithm for the R1CS ppzkSNARK");
+    m.def("r1cs_ppzksnark_affine_verifier_weak_IC", &r1cs_ppzksnark_affine_verifier_weak_IC<ppT>, "A verifier algorithm for the R1CS ppzkSNARK");
+}
+
+void init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_r1cs_ppzksnark(py::module &m)
+{
+    declare_r1cs_ppzksnark_proving_key(m);
+    declare_r1cs_ppzksnark_verification_key(m);
+    declare_r1cs_ppzksnark_processed_verification_key(m);
+    declare_r1cs_ppzksnark_keypair(m);
+    declare_r1cs_ppzksnark_proof(m);
+    declare_Main_algorithms(m);
+}

--- a/src/PyZPK/zk_proof_systems/ppzksnark/r1cs_ppzksnark/run_r1cs_ppzksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzksnark/r1cs_ppzksnark/run_r1cs_ppzksnark.cpp
@@ -1,0 +1,17 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/examples/run_r1cs_ppzksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+void init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_run_r1cs_ppzksnark(py::module &m)
+{
+    // Runs the ppzkSNARK (generator, prover, and verifier) for a given
+    // R1CS example (specified by a constraint system, input, and witness).
+
+    using ppT = mnt6_pp;
+    m.def("run_r1cs_ppzksnark", &run_r1cs_ppzksnark<ppT>);
+}


### PR DESCRIPTION
## Description
This PR adds bindings for r1cs ppzksnark (zk_proof_systems)

closes #42 
## How has this been tested?
- Added example bindings which is the utils for zpk_systems.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
