### PR TITLE
Add Bindings for r1cs_mp_ppzkpcd

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,9 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_pcd_params.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/r1cs_ppzksnark/run_r1cs_ppzksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/run_r1cs_mp_ppzkpcd.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -79,6 +79,9 @@ void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_pcd_params(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_tally_cp(py::module &);
 void init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_r1cs_ppzksnark(py::module &);
 void init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_run_r1cs_ppzksnark(py::module &);
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_mp_pcd_circuits(py::module &);
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_r1cs_mp_ppzkpcd(py::module &);
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_run_r1cs_mp_ppzkpcd_tally_example(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -162,4 +165,7 @@ PYBIND11_MODULE(pyzpk, m)
     init_zk_proof_systems_pcd_r1cs_pcd_tally_cp(m);
     init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_r1cs_ppzksnark(m);
     init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_run_r1cs_ppzksnark(m);
+    init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_mp_pcd_circuits(m);
+    init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_r1cs_mp_ppzkpcd(m);
+    init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_run_r1cs_mp_ppzkpcd_tally_example(m);
 }

--- a/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.cpp
+++ b/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.cpp
@@ -1,0 +1,62 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//  Declaration of functionality for creating and using the two PCD circuits in
+//  a multi-predicate PCD construction.
+
+void declare_mp_compliance_step_pcd_circuit_maker(py::module &m)
+{
+    // A compliance-step PCD circuit.
+    // The circuit is an R1CS that checks compliance (for the given compliance predicate)
+    // and validity of previous proofs.
+
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<mp_compliance_step_pcd_circuit_maker<ppT>>(m, "mp_compliance_step_pcd_circuit_maker")
+        .def(py::init<const r1cs_pcd_compliance_predicate<FieldT> &,
+                      const size_t>())
+        .def("generate_r1cs_constraints", &mp_compliance_step_pcd_circuit_maker<ppT>::generate_r1cs_constraints)
+        .def("get_circuit", &mp_compliance_step_pcd_circuit_maker<ppT>::get_circuit)
+        .def("get_primary_input", &mp_compliance_step_pcd_circuit_maker<ppT>::get_primary_input)
+        .def("get_auxiliary_input", &mp_compliance_step_pcd_circuit_maker<ppT>::get_auxiliary_input)
+        .def("field_logsize", &mp_compliance_step_pcd_circuit_maker<ppT>::field_logsize)
+        .def("field_capacity", &mp_compliance_step_pcd_circuit_maker<ppT>::field_capacity)
+        .def("input_size_in_elts", &mp_compliance_step_pcd_circuit_maker<ppT>::input_size_in_elts)
+        .def("input_capacity_in_bits", &mp_compliance_step_pcd_circuit_maker<ppT>::input_capacity_in_bits)
+        .def("input_size_in_bits", &mp_compliance_step_pcd_circuit_maker<ppT>::input_size_in_bits);
+}
+
+void declare_mp_translation_step_pcd_circuit_maker(py::module &m)
+{
+    // A translation-step PCD circuit.
+    // The circuit is an R1CS that checks validity of previous proofs.
+
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<mp_translation_step_pcd_circuit_maker<ppT>>(m, "mp_translation_step_pcd_circuit_maker")
+        .def(py::init<const r1cs_ppzksnark_verification_key<other_curve<ppT>> &>())
+        .def("generate_r1cs_constraints", &mp_translation_step_pcd_circuit_maker<ppT>::generate_r1cs_constraints)
+        .def("get_circuit", &mp_translation_step_pcd_circuit_maker<ppT>::get_circuit)
+        .def("generate_r1cs_witness", &mp_translation_step_pcd_circuit_maker<ppT>::get_circuit)
+        .def("get_primary_input", &mp_translation_step_pcd_circuit_maker<ppT>::get_primary_input)
+        .def("get_auxiliary_input", &mp_translation_step_pcd_circuit_maker<ppT>::get_auxiliary_input)
+        .def("field_logsize", &mp_translation_step_pcd_circuit_maker<ppT>::field_logsize)
+        .def("field_capacity", &mp_translation_step_pcd_circuit_maker<ppT>::field_capacity)
+        .def("input_size_in_elts", &mp_translation_step_pcd_circuit_maker<ppT>::input_size_in_elts)
+        .def("input_capacity_in_bits", &mp_translation_step_pcd_circuit_maker<ppT>::input_capacity_in_bits)
+        .def("input_size_in_bits", &mp_translation_step_pcd_circuit_maker<ppT>::input_size_in_bits);
+}
+
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_mp_pcd_circuits(py::module &m)
+{
+    declare_mp_compliance_step_pcd_circuit_maker(m);
+    declare_mp_translation_step_pcd_circuit_maker(m);
+}

--- a/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.cpp
+++ b/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.cpp
@@ -1,0 +1,215 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/common/default_types/r1cs_ppzkpcd_pp.hpp>
+#include <libsnark/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//  Interfaces for a multi-predicate ppzkPCD for R1CS.
+
+void declare_r1cs_mp_ppzkpcd_proving_key(py::module &m)
+{
+    // A proving key for the R1CS (multi-predicate) ppzkPCD.
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+    typedef typename PCD_ppT::curve_A_pp A_pp;
+    typedef typename PCD_ppT::curve_B_pp B_pp;
+
+    py::class_<r1cs_mp_ppzkpcd_proving_key<PCD_ppT>>(m, "r1cs_mp_ppzkpcd_proving_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_mp_ppzkpcd_proving_key<PCD_ppT> &>())
+        .def(py::init<const std::vector<r1cs_mp_ppzkpcd_compliance_predicate<PCD_ppT>> &,
+                      const std::vector<r1cs_ppzksnark_proving_key<A_pp>> &,
+                      const std::vector<r1cs_ppzksnark_proving_key<B_pp>> &,
+                      const std::vector<r1cs_ppzksnark_verification_key<A_pp>> &,
+                      const std::vector<r1cs_ppzksnark_verification_key<B_pp>> &,
+                      const set_commitment &,
+                      const std::vector<set_membership_proof> &,
+                      const std::map<size_t, size_t> &>())
+        .def_readwrite("compliance_predicates", &r1cs_mp_ppzkpcd_proving_key<PCD_ppT>::compliance_predicates)
+        .def_readwrite("compliance_step_r1cs_pks", &r1cs_mp_ppzkpcd_proving_key<PCD_ppT>::compliance_step_r1cs_pks)
+        .def_readwrite("translation_step_r1cs_pks", &r1cs_mp_ppzkpcd_proving_key<PCD_ppT>::translation_step_r1cs_pks)
+        .def_readwrite("compliance_step_r1cs_vks", &r1cs_mp_ppzkpcd_proving_key<PCD_ppT>::compliance_step_r1cs_vks)
+        .def_readwrite("translation_step_r1cs_vks", &r1cs_mp_ppzkpcd_proving_key<PCD_ppT>::translation_step_r1cs_vks)
+        .def_readwrite("commitment_to_translation_step_r1cs_vks", &r1cs_mp_ppzkpcd_proving_key<PCD_ppT>::commitment_to_translation_step_r1cs_vks)
+        .def_readwrite("compliance_step_r1cs_vk_membership_proofs", &r1cs_mp_ppzkpcd_proving_key<PCD_ppT>::compliance_step_r1cs_vk_membership_proofs)
+        .def_readwrite("compliance_predicate_name_to_idx", &r1cs_mp_ppzkpcd_proving_key<PCD_ppT>::compliance_predicate_name_to_idx)
+        .def("is_well_formed", &r1cs_mp_ppzkpcd_proving_key<PCD_ppT>::is_well_formed)
+        .def("__ostr__", [](r1cs_mp_ppzkpcd_proving_key<PCD_ppT> const &self) {
+            std::ostringstream os;
+            os << self.compliance_predicates;
+            os << self.compliance_step_r1cs_pks;
+            os << self.translation_step_r1cs_pks;
+            os << self.compliance_step_r1cs_vks;
+            os << self.translation_step_r1cs_vks;
+            output_bool_vector(os, self.commitment_to_translation_step_r1cs_vks);
+            os << self.compliance_step_r1cs_vk_membership_proofs;
+            os << self.compliance_predicate_name_to_idx;
+            return os;
+        })
+        .def("__istr__", [](r1cs_mp_ppzkpcd_proving_key<PCD_ppT> &self) {
+            std::istringstream in;
+            in >> self.compliance_predicates;
+            in >> self.compliance_step_r1cs_pks;
+            in >> self.translation_step_r1cs_pks;
+            in >> self.compliance_step_r1cs_vks;
+            in >> self.translation_step_r1cs_vks;
+            input_bool_vector(in, self.commitment_to_translation_step_r1cs_vks);
+            in >> self.compliance_step_r1cs_vk_membership_proofs;
+            in >> self.compliance_predicate_name_to_idx;
+            return in;
+        });
+}
+
+void declare_r1cs_mp_ppzkpcd_verification_key(py::module &m)
+{
+    //  A verification key for the R1CS (multi-predicate) ppzkPCD.
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+    typedef typename PCD_ppT::curve_A_pp A_pp;
+    typedef typename PCD_ppT::curve_B_pp B_pp;
+
+    py::class_<r1cs_mp_ppzkpcd_verification_key<PCD_ppT>>(m, "r1cs_mp_ppzkpcd_verification_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_mp_ppzkpcd_verification_key<PCD_ppT> &>())
+        .def(py::init<const std::vector<r1cs_ppzksnark_verification_key<A_pp>> &,
+                      const std::vector<r1cs_ppzksnark_verification_key<B_pp>> &,
+                      const set_commitment &>())
+        .def_readwrite("compliance_step_r1cs_vks", &r1cs_mp_ppzkpcd_verification_key<PCD_ppT>::compliance_step_r1cs_vks)
+        .def_readwrite("translation_step_r1cs_vks", &r1cs_mp_ppzkpcd_verification_key<PCD_ppT>::translation_step_r1cs_vks)
+        .def_readwrite("commitment_to_translation_step_r1cs_vks", &r1cs_mp_ppzkpcd_verification_key<PCD_ppT>::commitment_to_translation_step_r1cs_vks)
+        .def("size_in_bits", &r1cs_mp_ppzkpcd_verification_key<PCD_ppT>::size_in_bits)
+        .def(
+            "__eq__", [](r1cs_mp_ppzkpcd_verification_key<PCD_ppT> const &self, r1cs_mp_ppzkpcd_verification_key<PCD_ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_mp_ppzkpcd_verification_key<PCD_ppT> const &self) {
+            std::ostringstream os;
+            os << self.compliance_step_r1cs_vks;
+            os << self.translation_step_r1cs_vks;
+            libff::output_bool_vector(os, self.commitment_to_translation_step_r1cs_vks);
+            return os;
+        })
+        .def("__istr__", [](r1cs_mp_ppzkpcd_verification_key<PCD_ppT> &self) {
+            std::istringstream in;
+            in >> self.compliance_step_r1cs_vks;
+            in >> self.translation_step_r1cs_vks;
+            libff::input_bool_vector(in, self.commitment_to_translation_step_r1cs_vks);
+            return in;
+        });
+}
+
+void declare_r1cs_mp_ppzkpcd_processed_verification_key(py::module &m)
+{
+    // A processed verification key for the R1CS (multi-predicate) ppzkPCD.
+    // Compared to a (non-processed) verification key, a processed verification key
+    // contains a small constant amount of additional pre-computed information that
+    // enables a faster verification time.
+
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+    typedef typename PCD_ppT::curve_A_pp A_pp;
+    typedef typename PCD_ppT::curve_B_pp B_pp;
+
+    py::class_<r1cs_mp_ppzkpcd_processed_verification_key<PCD_ppT>>(m, "r1cs_mp_ppzkpcd_processed_verification_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_mp_ppzkpcd_processed_verification_key<PCD_ppT> &>())
+        .def(py::init<std::vector<r1cs_ppzksnark_processed_verification_key<A_pp>> &&,
+                      std::vector<r1cs_ppzksnark_processed_verification_key<B_pp>> &&,
+                      const set_commitment &>())
+        .def_readwrite("compliance_step_r1cs_pvks", &r1cs_mp_ppzkpcd_processed_verification_key<PCD_ppT>::compliance_step_r1cs_pvks)
+        .def_readwrite("translation_step_r1cs_pvks", &r1cs_mp_ppzkpcd_processed_verification_key<PCD_ppT>::translation_step_r1cs_pvks)
+        .def_readwrite("commitment_to_translation_step_r1cs_vks", &r1cs_mp_ppzkpcd_processed_verification_key<PCD_ppT>::commitment_to_translation_step_r1cs_vks)
+        .def(
+            "__eq__", [](r1cs_mp_ppzkpcd_processed_verification_key<PCD_ppT> const &self, r1cs_mp_ppzkpcd_processed_verification_key<PCD_ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_mp_ppzkpcd_processed_verification_key<PCD_ppT> const &self) {
+            std::ostringstream os;
+            os << self.compliance_step_r1cs_pvks;
+            os << self.translation_step_r1cs_pvks;
+            libff::output_bool_vector(os, self.commitment_to_translation_step_r1cs_vks);
+            return os;
+        })
+        .def("__istr__", [](r1cs_mp_ppzkpcd_processed_verification_key<PCD_ppT> &self) {
+            std::istringstream in;
+            in >> self.compliance_step_r1cs_pvks;
+            in >> self.translation_step_r1cs_pvks;
+            libff::input_bool_vector(in, self.commitment_to_translation_step_r1cs_vks);
+            return in;
+        });
+}
+
+void declare_r1cs_mp_ppzkpcd_keypair(py::module &m)
+{
+    // A key pair for the R1CS (multi-predicate) ppzkPC, which consists of a proving key and a verification key.
+
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+
+    py::class_<r1cs_mp_ppzkpcd_keypair<PCD_ppT>>(m, "r1cs_mp_ppzkpcd_keypair")
+        .def(py::init<>())
+        .def_readwrite("pk", &r1cs_mp_ppzkpcd_keypair<PCD_ppT>::pk)
+        .def_readwrite("vk", &r1cs_mp_ppzkpcd_keypair<PCD_ppT>::vk);
+}
+
+void declare_r1cs_mp_ppzkpcd_proof(py::module &m)
+{
+    // A proof for the R1CS (multi-predicate) ppzkPCD.
+
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+
+    py::class_<r1cs_mp_ppzkpcd_proof<PCD_ppT>>(m, "r1cs_mp_ppzkpcd_proof")
+        .def(py::init<>())
+        .def(py::init<const size_t,
+                      const r1cs_ppzksnark_proof<typename PCD_ppT::curve_B_pp> &>())
+        .def_readwrite("compliance_predicate_idx", &r1cs_mp_ppzkpcd_proof<PCD_ppT>::compliance_predicate_idx)
+        .def_readwrite("r1cs_proof", &r1cs_mp_ppzkpcd_proof<PCD_ppT>::r1cs_proof)
+        .def(
+            "__eq__", [](r1cs_mp_ppzkpcd_proof<PCD_ppT> const &self, r1cs_mp_ppzkpcd_proof<PCD_ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_mp_ppzkpcd_proof<PCD_ppT> const &self) {
+            std::ostringstream os;
+            os << self.compliance_predicate_idx << "\n";
+            os << self.r1cs_proof;
+            return os;
+        })
+        .def("__istr__", [](r1cs_mp_ppzkpcd_proof<PCD_ppT> &self) {
+            std::istringstream in;
+            in >> self.compliance_predicate_idx;
+            libff::consume_newline(in);
+            in >> self.r1cs_proof;
+            return in;
+        });
+}
+
+void declare_mp_Main_algorithms(py::module &m)
+{
+    // A proof for the R1CS (multi-predicate) ppzkPCD.
+
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+
+    // A generator algorithm for the R1CS (multi-predicate) ppzkPCD. 
+    // Given a vector of compliance predicates, this algorithm produces proving and verification keys for the vector.
+    m.def("r1cs_mp_ppzkpcd_generator", &r1cs_mp_ppzkpcd_generator<PCD_ppT>);
+
+    // A prover algorithm for the R1CS (multi-predicate) ppzkPCD.
+    // Given a proving key, name of chosen compliance predicate, inputs for the
+    // compliance predicate, and proofs for the predicate's input messages, this
+    // algorithm produces a proof (of knowledge) that attests to the compliance of
+    // the output message.
+    m.def("r1cs_mp_ppzkpcd_prover", &r1cs_mp_ppzkpcd_prover<PCD_ppT>);
+
+    // A verifier algorithm for the R1CS (multi-predicate) ppzkPCD that accepts a non-processed verification key.
+    m.def("r1cs_mp_ppzkpcd_verifier", &r1cs_mp_ppzkpcd_verifier<PCD_ppT>);
+
+    // Convert a (non-processed) verification key into a processed verification key.
+    m.def("r1cs_mp_ppzkpcd_process_vk", &r1cs_mp_ppzkpcd_process_vk<PCD_ppT>);
+
+    // A verifier algorithm for the R1CS (multi-predicate) ppzkPCD that accepts a processed verification key.
+    m.def("r1cs_mp_ppzkpcd_online_verifier", &r1cs_mp_ppzkpcd_online_verifier<PCD_ppT>);
+}
+
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_r1cs_mp_ppzkpcd(py::module &m)
+{
+    declare_r1cs_mp_ppzkpcd_proving_key(m);
+    declare_r1cs_mp_ppzkpcd_verification_key(m);
+    declare_r1cs_mp_ppzkpcd_processed_verification_key(m);
+    declare_r1cs_mp_ppzkpcd_keypair(m);
+    declare_r1cs_mp_ppzkpcd_proof(m);
+    declare_mp_Main_algorithms(m);
+}

--- a/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/run_r1cs_mp_ppzkpcd.cpp
+++ b/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/run_r1cs_mp_ppzkpcd.cpp
@@ -1,0 +1,23 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/common/default_types/r1cs_ppzkpcd_pp.hpp>
+#include <libsnark/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/examples/run_r1cs_mp_ppzkpcd.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+
+//  Declaration of functionality that runs the R1CS multi-predicate ppzkPCD
+//  for a compliance predicate example.
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_run_r1cs_mp_ppzkpcd_tally_example(py::module &m)
+{
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+
+    // Runs the multi-predicate ppzkPCD (generator, prover, and verifier) for the 
+    // "tally compliance predicate", of a given wordsize, arity, and depth.
+    // Optionally, also test the serialization routines for keys and proofs. (This takes additional time.) 
+    // Optionally, also test the case of compliance predicates with different types.
+    m.def("run_r1cs_mp_ppzkpcd_tally_example", &run_r1cs_mp_ppzkpcd_tally_example<PCD_ppT>);
+}

--- a/test/test_zk_proof_systems.py
+++ b/test/test_zk_proof_systems.py
@@ -18,3 +18,73 @@ def test_compliance_predicate():
     cp_1 = tally_1.get_compliance_predicate()
     cp_2 = tally_2.get_compliance_predicate()
     assert cp_1 and cp_2
+
+def test_r1cs_mp_ppzkpcd():
+    max_arity = 2
+    depth = 2 #max_layer
+    wordsize = 32
+    test_serialization = True
+    test_multi_type = True
+    test_same_type_optimization = False
+    all_accept = True
+    tree_size = 0
+    nodes_in_layer = 1
+    for layer in range(depth+2):
+        tree_size = tree_size + nodes_in_layer
+        nodes_in_layer = nodes_in_layer*max_arity
+
+    tree_types = []
+    tree_elems = []
+    tree_arity = []
+    for i in range(tree_size):
+        tree_arity.append(0)
+        tree_elems.append(0)
+        tree_types.append(0)
+
+    nodes_in_layer = 1
+    node_idx = 0
+    for layer in range(0, depth+1):
+        for id_in_layer in range(0, nodes_in_layer+1):
+            if(not test_multi_type):
+                print(node_idx)
+                tree_types[node_idx] = 1
+            else:
+                if(test_same_type_optimization):
+                    tree_types[node_idx] = 1 + ((depth-layer) & 1)
+                    print(node_idx)
+                else:
+                    tree_types[node_idx] = 1 + random.randint(0, RAND_MAX) % 2
+            tree_elems[node_idx] = random.randint(0, RAND_MAX) % 100
+            tree_arity[node_idx] = 1 + (random.randint(0, RAND_MAX) % max_arity)
+            node_idx = node_idx + 1
+        nodes_in_layer = nodes_in_layer * max_arity
+        
+    tree_proofs = []
+    tree_messages = []
+    for i in range(tree_size):
+        tree_proofs.append(0)
+        tree_messages.append(0)
+
+    tally_1_accepted_types = {1,2}
+    tally_2_accepted_types = {1}
+    tally_1 = pyzpk.tally_cp_handler(1, max_arity, wordsize, test_same_type_optimization, tally_1_accepted_types)
+    tally_2 = pyzpk.tally_cp_handler(2, max_arity, wordsize, test_same_type_optimization, tally_2_accepted_types)
+    tally_1.generate_r1cs_constraints()
+    tally_2.generate_r1cs_constraints()
+    cp_1 = tally_1.get_compliance_predicate()
+    cp_2 = tally_2.get_compliance_predicate()
+
+    nodes_in_layer =  nodes_in_layer//max_arity
+    layer = depth
+    while layer >= 0:
+        for i in range(0, nodes_in_layer+1):
+            cur_idx = (nodes_in_layer - 1) // (max_arity - 1) + i
+            cur_tally = tally_1 if tree_types[cur_idx] == 1 else tally_2
+            cur_cp = cp_1 if tree_types[cur_idx] == 1 else cp_2
+            base_case = (max_arity * cur_idx + max_arity >= tree_size)
+            proofs = []
+            if not base_case:
+                for i in range(0, max_arity):
+                    proofs.append(tree_proofs[max_arity*cur_idx + i + 1])   
+        layer = layer - 1
+        nodes_in_layer = nodes_in_layer//max_arity


### PR DESCRIPTION
## Description
This PR adds bindings for r1cs multi-predicate ppzkpcd (zk_proof_systems)

closes #43 

## How has this been tested?
- This can be tested by running `pytest test` from the root folder.


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
