### PR TITLE
Add Bindings for r1cs sp ppzkpcd

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,9 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/mp_pcd_circuits.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/r1cs_mp_ppzkpcd.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_mp_ppzkpcd/run_r1cs_mp_ppzkpcd.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/run_r1cs_sp_ppzkpcd.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -82,6 +82,9 @@ void init_zk_proof_systems_ppzksnark_r1cs_ppzksnark_run_r1cs_ppzksnark(py::modul
 void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_mp_pcd_circuits(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_r1cs_mp_ppzkpcd(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_run_r1cs_mp_ppzkpcd_tally_example(py::module &);
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_r1cs_sp_ppzkpcd(py::module &);
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_sp_pcd_circuits(py::module &);
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_run_r1cs_sp_ppzkpcd(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -168,4 +171,7 @@ PYBIND11_MODULE(pyzpk, m)
     init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_mp_pcd_circuits(m);
     init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_r1cs_mp_ppzkpcd(m);
     init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_run_r1cs_mp_ppzkpcd_tally_example(m);
+    init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_r1cs_sp_ppzkpcd(m);
+    init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_sp_pcd_circuits(m);
+    init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_run_r1cs_sp_ppzkpcd(m);
 }

--- a/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.cpp
+++ b/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.cpp
@@ -1,0 +1,142 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/common/default_types/r1cs_ppzkpcd_pp.hpp>
+#include <libsnark/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//  Interfaces for a *single-predicate* ppzkPCD for R1CS.
+
+void declare_r1cs_sp_ppzkpcd_proving_key(py::module &m)
+{
+    // A proving key for the R1CS (single-predicate) ppzkPCD.
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+    typedef typename PCD_ppT::curve_A_pp A_pp;
+    typedef typename PCD_ppT::curve_B_pp B_pp;
+
+    py::class_<r1cs_sp_ppzkpcd_proving_key<PCD_ppT>>(m, "r1cs_sp_ppzkpcd_proving_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_sp_ppzkpcd_proving_key<PCD_ppT> &>())
+        .def("size_in_bits", &r1cs_sp_ppzkpcd_proving_key<PCD_ppT>::size_in_bits)
+        .def(
+            "__eq__", [](r1cs_sp_ppzkpcd_proving_key<PCD_ppT> const &self, r1cs_sp_ppzkpcd_proving_key<PCD_ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_sp_ppzkpcd_proving_key<PCD_ppT> const &self) {
+        std::ostringstream os;
+        os << self.compliance_predicate;
+        os << self.compliance_step_r1cs_pk;
+        os << self.translation_step_r1cs_pk;
+        os << self.compliance_step_r1cs_vk;
+        os << self.translation_step_r1cs_vk;
+        return os;
+            })
+        .def("__istr__", [](r1cs_sp_ppzkpcd_proving_key<PCD_ppT> &self) {
+                std::istringstream in;
+                in >> self.compliance_predicate;
+                in >> self.compliance_step_r1cs_pk;
+                in >> self.translation_step_r1cs_pk;
+                in >> self.compliance_step_r1cs_vk;
+                in >> self.translation_step_r1cs_vk;
+                return in;
+            });
+}
+
+void declare_r1cs_sp_ppzkpcd_verification_key(py::module &m)
+{
+    // A verification key for the R1CS (single-predicate) ppzkPCD.
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+    typedef typename PCD_ppT::curve_A_pp A_pp;
+    typedef typename PCD_ppT::curve_B_pp B_pp;
+
+    py::class_<r1cs_sp_ppzkpcd_verification_key<PCD_ppT>>(m, "r1cs_sp_ppzkpcd_verification_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_sp_ppzkpcd_verification_key<PCD_ppT> &>())
+        .def(py::init<const r1cs_ppzksnark_verification_key<A_pp> &,
+            const r1cs_ppzksnark_verification_key<B_pp> &>())
+        .def("size_in_bits", &r1cs_sp_ppzkpcd_verification_key<PCD_ppT>::size_in_bits)
+        .def(
+            "__eq__", [](r1cs_sp_ppzkpcd_verification_key<PCD_ppT> const &self, r1cs_sp_ppzkpcd_verification_key<PCD_ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_sp_ppzkpcd_verification_key<PCD_ppT> const &self) {
+        std::ostringstream os;
+        os << self.compliance_step_r1cs_vk;
+        os << self.translation_step_r1cs_vk;
+        return os;
+            })
+        .def("__istr__", [](r1cs_sp_ppzkpcd_verification_key<PCD_ppT> &self) {
+                std::istringstream in;
+                in >> self.compliance_step_r1cs_vk;
+                in >> self.translation_step_r1cs_vk;
+                return in;
+            });
+}
+
+void declare_r1cs_sp_ppzkpcd_processed_verification_key(py::module &m)
+{
+    // A processed verification key for the R1CS (single-predicate) ppzkPCD.
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+    typedef typename PCD_ppT::curve_A_pp A_pp;
+    typedef typename PCD_ppT::curve_B_pp B_pp;
+
+    py::class_<r1cs_sp_ppzkpcd_processed_verification_key<PCD_ppT>>(m, "r1cs_sp_ppzkpcd_processed_verification_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_sp_ppzkpcd_processed_verification_key<PCD_ppT> &>())
+        .def(
+            "__eq__", [](r1cs_sp_ppzkpcd_processed_verification_key<PCD_ppT> const &self, r1cs_sp_ppzkpcd_processed_verification_key<PCD_ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_sp_ppzkpcd_processed_verification_key<PCD_ppT> const &self) {
+        std::ostringstream os;
+        os << self.compliance_step_r1cs_pvk;
+        os << self.translation_step_r1cs_pvk;
+        libff::serialize_bit_vector(os, self.translation_step_r1cs_vk_bits);
+        return os;
+            })
+        .def("__istr__", [](r1cs_sp_ppzkpcd_processed_verification_key<PCD_ppT> &self) {
+                std::istringstream in;
+                in >> self.compliance_step_r1cs_pvk;
+                in >> self.translation_step_r1cs_pvk;
+                libff::deserialize_bit_vector(in, self.translation_step_r1cs_vk_bits);
+                return in;
+            });
+}
+
+void declare_r1cs_sp_ppzkpcd_keypair(py::module &m)
+{
+    // A key pair for the R1CS (single-predicate) ppzkPC, which consists of a proving key and a verification key.
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+
+    py::class_<r1cs_sp_ppzkpcd_keypair<PCD_ppT>>(m, "r1cs_sp_ppzkpcd_keypair")
+        .def(py::init<>());
+}
+
+void declare_sp_Main_algorithms(py::module &m)
+{
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+    // A generator algorithm for the R1CS (single-predicate) ppzkPCD.
+    // Given a compliance predicate, this algorithm produces proving and verification keys for the predicate.
+    m.def("r1cs_sp_ppzkpcd_generator", &r1cs_sp_ppzkpcd_generator<PCD_ppT>);
+
+    // A prover algorithm for the R1CS (single-predicate) ppzkPCD.
+    // Given a proving key, inputs for the compliance predicate, and proofs for
+    // the predicate's input messages, this algorithm produces a proof (of knowledge)
+    // that attests to the compliance of the output message.
+    m.def("r1cs_sp_ppzkpcd_prover", &r1cs_sp_ppzkpcd_prover<PCD_ppT>);
+
+    // A verifier algorithm for the R1CS (single-predicate) ppzkPCD that accepts a non-processed verification key.
+    m.def("r1cs_sp_ppzkpcd_verifier", &r1cs_sp_ppzkpcd_verifier<PCD_ppT>);
+
+    // Convert a (non-processed) verification key into a processed verification key.
+    m.def("r1cs_sp_ppzkpcd_process_vk", &r1cs_sp_ppzkpcd_process_vk<PCD_ppT>);
+
+    // A verifier algorithm for the R1CS (single-predicate) ppzkPCD that accepts a processed verification key.
+    m.def("r1cs_sp_ppzkpcd_online_verifier", &r1cs_sp_ppzkpcd_online_verifier<PCD_ppT>);
+
+}
+
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_r1cs_sp_ppzkpcd(py::module &m)
+{
+    declare_r1cs_sp_ppzkpcd_proving_key(m);
+    declare_r1cs_sp_ppzkpcd_verification_key(m);
+    declare_r1cs_sp_ppzkpcd_processed_verification_key(m);
+    declare_r1cs_sp_ppzkpcd_keypair(m);
+}

--- a/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/run_r1cs_sp_ppzkpcd.cpp
+++ b/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/run_r1cs_sp_ppzkpcd.cpp
@@ -1,0 +1,20 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/common/default_types/r1cs_ppzkpcd_pp.hpp>
+#include <libsnark/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/examples/run_r1cs_sp_ppzkpcd.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Declaration of functionality that runs the R1CS single-predicate ppzkPCD
+// for a compliance predicate example.
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_run_r1cs_sp_ppzkpcd(py::module &m)
+{
+    using PCD_ppT = default_r1cs_ppzkpcd_pp;
+
+    // Runs the single-predicate ppzkPCD (generator, prover, and verifier) for the
+    // "tally compliance predicate", of a given wordsize, arity, and depth.
+    m.def("run_r1cs_sp_ppzkpcd_tally_example", &run_r1cs_sp_ppzkpcd_tally_example<PCD_ppT>);
+}

--- a/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.cpp
+++ b/src/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.cpp
@@ -1,0 +1,58 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libsnark/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//   Declaration of functionality for creating and using the two PCD circuits in
+//  a single-predicate PCD construction.
+
+void declare_sp_compliance_step_pcd_circuit_maker(py::module &m)
+{
+    // A compliance-step PCD circuit.
+    // The circuit is an R1CS that checks compliance (for the given compliance predicate) and validity of previous proofs.
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<sp_compliance_step_pcd_circuit_maker<ppT>>(m, "sp_compliance_step_pcd_circuit_maker")
+        .def(py::init<const r1cs_pcd_compliance_predicate<FieldT> &>())
+        .def("generate_r1cs_constraints", &sp_compliance_step_pcd_circuit_maker<ppT>::generate_r1cs_constraints)
+        .def("get_circuit", &sp_compliance_step_pcd_circuit_maker<ppT>::get_circuit)
+        .def("get_primary_input", &sp_compliance_step_pcd_circuit_maker<ppT>::get_primary_input)
+        .def("get_auxiliary_input", &sp_compliance_step_pcd_circuit_maker<ppT>::get_auxiliary_input)
+        .def("field_logsize", &sp_compliance_step_pcd_circuit_maker<ppT>::field_logsize)
+        .def("field_capacity", &sp_compliance_step_pcd_circuit_maker<ppT>::field_capacity)
+        .def("input_size_in_elts", &sp_compliance_step_pcd_circuit_maker<ppT>::input_size_in_elts)
+        .def("input_capacity_in_bits", &sp_compliance_step_pcd_circuit_maker<ppT>::input_capacity_in_bits)
+        .def("input_size_in_bits", &sp_compliance_step_pcd_circuit_maker<ppT>::input_size_in_bits);
+}
+
+void declare_sp_translation_step_pcd_circuit_maker(py::module &m)
+{
+    // A compliance-step PCD circuit.
+    // The circuit is an R1CS that checks compliance (for the given compliance predicate) and validity of previous proofs.
+    using ppT = mnt6_pp;
+    using FieldT = Fr<ppT>;
+
+    py::class_<sp_translation_step_pcd_circuit_maker<ppT>>(m, "sp_translation_step_pcd_circuit_maker")
+        .def(py::init<const r1cs_ppzksnark_verification_key<other_curve<ppT> > &>())
+        .def("generate_r1cs_constraints", &sp_translation_step_pcd_circuit_maker<ppT>::generate_r1cs_constraints)
+        .def("get_circuit", &sp_translation_step_pcd_circuit_maker<ppT>::get_circuit)
+        .def("generate_r1cs_witness", &sp_translation_step_pcd_circuit_maker<ppT>::generate_r1cs_witness)
+        .def("get_primary_input", &sp_translation_step_pcd_circuit_maker<ppT>::get_primary_input)
+        .def("get_auxiliary_input", &sp_translation_step_pcd_circuit_maker<ppT>::get_auxiliary_input)
+        .def("field_logsize", &sp_translation_step_pcd_circuit_maker<ppT>::field_logsize)
+        .def("field_capacity", &sp_translation_step_pcd_circuit_maker<ppT>::field_capacity)
+        .def("input_size_in_elts", &sp_translation_step_pcd_circuit_maker<ppT>::input_size_in_elts)
+        .def("input_capacity_in_bits", &sp_translation_step_pcd_circuit_maker<ppT>::input_capacity_in_bits)
+        .def("input_size_in_bits", &sp_translation_step_pcd_circuit_maker<ppT>::input_size_in_bits);
+}
+
+void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_sp_pcd_circuits(py::module &m)
+{
+    declare_sp_compliance_step_pcd_circuit_maker(m);
+    declare_sp_translation_step_pcd_circuit_maker(m);
+}

--- a/test/test_zk_proof_systems.py
+++ b/test/test_zk_proof_systems.py
@@ -88,3 +88,35 @@ def test_r1cs_mp_ppzkpcd():
                     proofs.append(tree_proofs[max_arity*cur_idx + i + 1])   
         layer = layer - 1
         nodes_in_layer = nodes_in_layer//max_arity
+        
+def test_r1cs_sp_ppzkpcd():
+    max_arity = 2
+    depth = 2 #max_layer
+    wordsize = 32
+    test_serialization = True
+    all_accept = True
+    tree_size = 0
+    nodes_in_layer = 1
+    for layer in range(depth+2):
+        tree_size = tree_size + nodes_in_layer
+        nodes_in_layer = nodes_in_layer*max_arity
+
+    tree_elems = []
+    for i in range(tree_size + 1):
+        tree_elems.append(0)
+    for i in range(0, tree_size+1):
+        tree_elems[i] = random.randint(0, RAND_MAX) % 10
+
+    tree_proofs = []
+    tree_messages = []
+    for i in range(tree_size):
+        tree_proofs.append(0)
+        tree_messages.append(0)
+
+    type = 1
+    tally_accepted_types = {1,2}
+    test_same_type_optimization = True
+    tally = pyzpk.tally_cp_handler(type, max_arity, wordsize, test_same_type_optimization, tally_accepted_types)
+    tally.generate_r1cs_constraints()
+    tally_cp = tally.get_compliance_predicate()
+    nodes_in_layer =  nodes_in_layer//max_arity


### PR DESCRIPTION
## Description
This PR adds bindings for r1cs single-predicate ppzkpcd (zk_proof_systems)

closes #44 

## How has this been tested?
- This can be tested by running `pytest test` from the root folder.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
