### PR TITLE
Add Bindings for r1cs ppzkadsnark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,8 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/r1cs_sp_ppzkpcd.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/sp_pcd_circuits.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/run_r1cs_sp_ppzkpcd.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_params_prf_signature.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -85,6 +85,8 @@ void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_mp_ppzkpcd_run_r1cs_mp_ppzkpcd_tall
 void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_r1cs_sp_ppzkpcd(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_sp_pcd_circuits(py::module &);
 void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_run_r1cs_sp_ppzkpcd(py::module &);
+void init_zk_proof_systems_ppzkadsnark_r1cs_ppzkadsnark_r1cs_ppzkadsnark(py::module &);
+void init_zk_proof_systems_ppzkadsnark_r1cs_ppzkadsnark_params_prf_signature(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -174,4 +176,6 @@ PYBIND11_MODULE(pyzpk, m)
     init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_r1cs_sp_ppzkpcd(m);
     init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_sp_pcd_circuits(m);
     init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_run_r1cs_sp_ppzkpcd(m);
+    init_zk_proof_systems_ppzkadsnark_r1cs_ppzkadsnark_r1cs_ppzkadsnark(m);
+    init_zk_proof_systems_ppzkadsnark_r1cs_ppzkadsnark_params_prf_signature(m);
 }

--- a/src/PyZPK/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.cpp
@@ -1,0 +1,325 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/r1cs_ppzkadsnark_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//  Declaration of interfaces for a ppzkADSNARK for R1CS.
+//  This includes:
+//  - class for authentication key (public and symmetric)
+//  - class for authentication verification key (public and symmetric)
+//  - class for proving key
+//  - class for verification key
+//  - class for processed verification key
+//  - class for key tuple (authentication key & proving key & verification key)
+//  - class for authenticated data
+//  - class for proof
+//  - generator algorithm
+//  - authentication key generator algorithm
+//  - prover algorithm
+//  - verifier algorithm (public and symmetric)
+//  - online verifier algorithm (public and symmetric)
+//  The implementation instantiates the construction in \[BBFR15], which in turn
+//  is based on the r1cs_ppzkadsnark proof system.
+
+// ppzkADSNARK = "PreProcessing Zero-Knowledge Succinct Non-interactive ARgument of Knowledge Over Authenticated Data"
+
+void declare_r1cs_ppzkadsnark_pub_auth_prms(py::module &m)
+{
+    // public authentication parameters for the R1CS ppzkADSNARK
+
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<r1cs_ppzkadsnark_pub_auth_prms<ppT>>(m, "r1cs_ppzkadsnark_pub_auth_prms")
+        .def(py::init<>())
+        .def(py::init<const r1cs_ppzkadsnark_pub_auth_prms<ppT> &>())
+        .def(
+            "__eq__", [](r1cs_ppzkadsnark_pub_auth_prms<ppT> const &self, r1cs_ppzkadsnark_pub_auth_prms<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_ppzkadsnark_pub_auth_prms<ppT> const &self) {
+        std::ostringstream os;
+        os << self.I1;
+        return os;
+            })
+        .def("__istr__", [](r1cs_ppzkadsnark_pub_auth_prms<ppT> &self) {
+                std::istringstream in;
+                in >> self.I1;
+                return in;
+            });
+}
+
+void declare_r1cs_ppzkadsnark_sec_auth_key(py::module &m)
+{
+    // Secret authentication key for the R1CS ppzkADSNARK
+
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<r1cs_ppzkadsnark_sec_auth_key<ppT>>(m, "r1cs_ppzkadsnark_sec_auth_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_ppzkadsnark_sec_auth_key<ppT> &>());
+}
+
+void declare_r1cs_ppzkadsnark_pub_auth_key(py::module &m)
+{
+    // public authentication Key for the R1CS ppzkADSNARK
+
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<r1cs_ppzkadsnark_pub_auth_key<ppT>>(m, "r1cs_ppzkadsnark_pub_auth_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_ppzkadsnark_pub_auth_key<ppT> &>());
+}
+
+void declare_r1cs_ppzkadsnark_auth_keys(py::module &m)
+{
+    // Authentication key material
+
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<r1cs_ppzkadsnark_auth_keys<ppT>>(m, "r1cs_ppzkadsnark_auth_keys")
+        .def(py::init<>());
+}
+
+void declare_r1cs_ppzkadsnark_auth_data(py::module &m)
+{
+    // Authenticated data for the R1CS ppzkADSNARK
+
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<r1cs_ppzkadsnark_auth_data<ppT>>(m, "r1cs_ppzkadsnark_auth_data")
+        .def(py::init<>())
+        .def(py::init<const r1cs_ppzkadsnark_auth_data<ppT> &>())
+        .def("__ostr__", [](r1cs_ppzkadsnark_auth_data<ppT> const &self) {
+        std::ostringstream os;
+        os << self.mu;
+        os << self.Lambda;
+        return os;
+            })
+        .def("__istr__", [](r1cs_ppzkadsnark_auth_data<ppT> &self) {
+                std::istringstream in;
+                in >> self.mu;
+                in >> self.Lambda;
+                return in;
+            });
+}
+
+void declare_r1cs_ppzkadsnark_proving_key(py::module &m)
+{
+    // A proving key for the R1CS ppzkADSNARK.
+
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<r1cs_ppzkadsnark_proving_key<ppT>>(m, "r1cs_ppzkadsnark_proving_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_ppzkadsnark_proving_key<ppT> &>())
+        .def("G1_size", &r1cs_ppzkadsnark_proving_key<ppT>::G1_size)
+        .def("G2_size", &r1cs_ppzkadsnark_proving_key<ppT>::G2_size)
+        .def("G1_sparse_size", &r1cs_ppzkadsnark_proving_key<ppT>::G1_sparse_size)
+        .def("G2_sparse_size", &r1cs_ppzkadsnark_proving_key<ppT>::G2_sparse_size)
+        .def("size_in_bits", &r1cs_ppzkadsnark_proving_key<ppT>::size_in_bits)
+        .def("print_size", &r1cs_ppzkadsnark_proving_key<ppT>::print_size)
+        .def(
+            "__eq__", [](r1cs_ppzkadsnark_proving_key<ppT> const &self, r1cs_ppzkadsnark_proving_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_ppzkadsnark_proving_key<ppT> const &self) {
+        std::ostringstream os;
+        os << self.A_query;
+        os << self.B_query;
+        os << self.C_query;
+        os << self.H_query;
+        os << self.K_query;
+        os << self.rA_i_Z_g1;
+        os << self.constraint_system;
+        return os;
+            })
+        .def("__istr__", [](r1cs_ppzkadsnark_proving_key<ppT> &self) {
+                std::istringstream in;
+                in >> self.A_query;
+                in >> self.B_query;
+                in >> self.C_query;
+                in >> self.H_query;
+                in >> self.K_query;
+                in >> self.rA_i_Z_g1;
+                in >> self.constraint_system;
+                return in;
+            });
+}
+
+void declare_r1cs_ppzkadsnark_verification_key(py::module &m)
+{
+    // A verification key for the R1CS ppzkADSNARK.
+
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<r1cs_ppzkadsnark_verification_key<ppT>>(m, "r1cs_ppzkadsnark_verification_key")
+        .def(py::init<>())
+        .def("G1_size", &r1cs_ppzkadsnark_verification_key<ppT>::G1_size)
+        .def("G2_size", &r1cs_ppzkadsnark_verification_key<ppT>::G2_size)
+        .def("size_in_bits", &r1cs_ppzkadsnark_verification_key<ppT>::size_in_bits)
+        .def("print_size", &r1cs_ppzkadsnark_verification_key<ppT>::print_size)
+        .def(
+            "__eq__", [](r1cs_ppzkadsnark_verification_key<ppT> const &self, r1cs_ppzkadsnark_verification_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_ppzkadsnark_verification_key<ppT> const &self) {
+        std::ostringstream os;
+        os << self.alphaA_g2 << OUTPUT_NEWLINE;
+        os << self.alphaB_g1 << OUTPUT_NEWLINE;
+        os << self.alphaC_g2 << OUTPUT_NEWLINE;
+        os << self.gamma_g2 << OUTPUT_NEWLINE;
+        os << self.gamma_beta_g1 << OUTPUT_NEWLINE;
+        os << self.gamma_beta_g2 << OUTPUT_NEWLINE;
+        os << self.rC_Z_g2 << OUTPUT_NEWLINE;
+        os << self.A0 << OUTPUT_NEWLINE;
+        os << self.Ain << OUTPUT_NEWLINE;
+        return os;
+            })
+        .def("__istr__", [](r1cs_ppzkadsnark_verification_key<ppT> &self) {
+                std::istringstream in;
+                in >> self.alphaA_g2;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.alphaB_g1;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.alphaC_g2;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.gamma_g2;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.gamma_beta_g1;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.gamma_beta_g2;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.rC_Z_g2;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.A0;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.Ain;
+                libff::consume_OUTPUT_NEWLINE(in);
+                return in;
+            });
+}
+
+void declare_r1cs_ppzkadsnark_processed_verification_key(py::module &m)
+{
+    // A processed verification key for the R1CS ppzkADSNARK.
+
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<r1cs_ppzkadsnark_processed_verification_key<ppT>>(m, "r1cs_ppzkadsnark_processed_verification_key")
+        .def(py::init<>())
+        .def(
+            "__eq__", [](r1cs_ppzkadsnark_processed_verification_key<ppT> const &self, r1cs_ppzkadsnark_processed_verification_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_ppzkadsnark_processed_verification_key<ppT> const &self) {
+        std::ostringstream os;
+        os << self.pp_G2_one_precomp << OUTPUT_NEWLINE;
+        os << self.vk_alphaA_g2_precomp << OUTPUT_NEWLINE;
+        os << self.vk_alphaB_g1_precomp << OUTPUT_NEWLINE;
+        os << self.vk_alphaC_g2_precomp << OUTPUT_NEWLINE;
+        os << self.vk_rC_Z_g2_precomp << OUTPUT_NEWLINE;
+        os << self.vk_gamma_g2_precomp << OUTPUT_NEWLINE;
+        os << self.vk_gamma_beta_g1_precomp << OUTPUT_NEWLINE;
+        os << self.vk_gamma_beta_g2_precomp << OUTPUT_NEWLINE;
+        os << self.vk_rC_i_g2_precomp << OUTPUT_NEWLINE;
+        os << self.A0 << OUTPUT_NEWLINE;
+        os << self.Ain << OUTPUT_NEWLINE;
+        os << self.proof_g_vki_precomp  << OUTPUT_NEWLINE;
+        return os;
+            })
+        .def("__istr__", [](r1cs_ppzkadsnark_processed_verification_key<ppT> &self) {
+                std::istringstream in;
+                in >> self.pp_G2_one_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.vk_alphaA_g2_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.vk_alphaB_g1_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.vk_alphaC_g2_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.vk_rC_Z_g2_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.vk_gamma_g2_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.vk_gamma_beta_g1_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.vk_gamma_beta_g2_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.vk_rC_i_g2_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.A0;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.Ain;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.proof_g_vki_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                return in;
+            });
+}
+
+void declare_r1cs_ppzkadsnark_keypair(py::module &m)
+{
+    // A key pair for the R1CS ppzkADSNARK, which consists of a proving key and a verification key.
+
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<r1cs_ppzkadsnark_keypair<ppT>>(m, "r1cs_ppzkadsnark_keypair")
+        .def(py::init<>())
+        .def(py::init<const r1cs_ppzkadsnark_keypair<ppT> &>());
+}
+
+void declare_r1cs_ppzkadsnark_proof(py::module &m)
+{
+    // A proof for the R1CS ppzkADSNARK.
+
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<r1cs_ppzkadsnark_proof<ppT>>(m, "r1cs_ppzkadsnark_proof")
+        .def(py::init<>())
+        .def("G1_size", &r1cs_ppzkadsnark_proof<ppT>::G1_size)
+        .def("G2_size", &r1cs_ppzkadsnark_proof<ppT>::G2_size)
+        .def("size_in_bits", &r1cs_ppzkadsnark_proof<ppT>::size_in_bits)
+        .def("print_size", &r1cs_ppzkadsnark_proof<ppT>::print_size)
+        .def("is_well_formed", &r1cs_ppzkadsnark_proof<ppT>::is_well_formed)
+        .def(
+            "__eq__", [](r1cs_ppzkadsnark_proof<ppT> const &self, r1cs_ppzkadsnark_proof<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_ppzkadsnark_proof<ppT> const &self) {
+        std::ostringstream os;
+        os << self.g_A << OUTPUT_NEWLINE;
+        os << self.g_B << OUTPUT_NEWLINE;
+        os << self.g_C << OUTPUT_NEWLINE;
+        os << self.g_H << OUTPUT_NEWLINE;
+        os << self.g_K << OUTPUT_NEWLINE;
+        os << self.g_Aau << OUTPUT_NEWLINE;
+        os << self.muA << OUTPUT_NEWLINE;
+        return os;
+            })
+        .def("__istr__", [](r1cs_ppzkadsnark_proof<ppT> &self) {
+                std::istringstream in;
+                in >> self.g_A;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.g_B;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.g_C;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.g_H;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.g_K;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.g_Aau;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.muA;
+                libff::consume_OUTPUT_NEWLINE(in);
+                return in;
+            });
+}
+
+void init_zk_proof_systems_ppzkadsnark_r1cs_ppzkadsnark_r1cs_ppzkadsnark(py::module &m)
+{
+    declare_r1cs_ppzkadsnark_pub_auth_prms(m);
+    declare_r1cs_ppzkadsnark_sec_auth_key(m);
+    declare_r1cs_ppzkadsnark_pub_auth_key(m);
+    declare_r1cs_ppzkadsnark_auth_keys(m);
+    declare_r1cs_ppzkadsnark_auth_data(m);
+    declare_r1cs_ppzkadsnark_proving_key(m);
+    declare_r1cs_ppzkadsnark_verification_key(m);
+    declare_r1cs_ppzkadsnark_processed_verification_key(m);
+    declare_r1cs_ppzkadsnark_keypair(m);
+    declare_r1cs_ppzkadsnark_proof(m);
+}

--- a/src/PyZPK/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_params_prf_signature.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_params_prf_signature.cpp
@@ -1,0 +1,32 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/r1cs_ppzkadsnark_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_params.hpp>
+#include <libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_prf.hpp>
+#include <libsnark/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_signature.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+void declare_r1cs_ppzkadsnark_params(py::module &m)
+{
+    // Public-parameter selector for the R1CS ppzkADSNARK.
+
+    py::class_<labelT>(m, "labelT")
+        .def(py::init<>());
+}
+
+void declare_r1cs_ppzkadsnark_signature(py::module &m)
+{
+    //  Generic signature interface for ADSNARK.
+    using ppT = default_r1cs_ppzkadsnark_pp;
+
+    py::class_<kpT<ppT>>(m, "kpT");
+}
+
+void init_zk_proof_systems_ppzkadsnark_r1cs_ppzkadsnark_params_prf_signature(py::module &m)
+{
+    declare_r1cs_ppzkadsnark_params(m);
+    declare_r1cs_ppzkadsnark_signature(m);
+}

--- a/test/test_zk_proof_systems.py
+++ b/test/test_zk_proof_systems.py
@@ -3,6 +3,7 @@ import pyzpk
 import math
 RAND_MAX = 32767
 
+
 def test_compliance_predicate():
     type_1 = 1
     type_2 = 2
@@ -11,17 +12,20 @@ def test_compliance_predicate():
     relies_on_same_type_inputs = False
     tally_1_accepted_types = {1}
     tally_2_accepted_types = {2, 1}
-    tally_1 = pyzpk.tally_cp_handler(type_1, max_arity, wordsize, relies_on_same_type_inputs, tally_1_accepted_types)
-    tally_2 = pyzpk.tally_cp_handler(type_2, max_arity, wordsize, relies_on_same_type_inputs, tally_2_accepted_types)
+    tally_1 = pyzpk.tally_cp_handler(
+        type_1, max_arity, wordsize, relies_on_same_type_inputs, tally_1_accepted_types)
+    tally_2 = pyzpk.tally_cp_handler(
+        type_2, max_arity, wordsize, relies_on_same_type_inputs, tally_2_accepted_types)
     tally_1.generate_r1cs_constraints()
     tally_2.generate_r1cs_constraints()
     cp_1 = tally_1.get_compliance_predicate()
     cp_2 = tally_2.get_compliance_predicate()
     assert cp_1 and cp_2
 
+
 def test_r1cs_mp_ppzkpcd():
     max_arity = 2
-    depth = 2 #max_layer
+    depth = 2  # max_layer
     wordsize = 32
     test_serialization = True
     test_multi_type = True
@@ -55,26 +59,29 @@ def test_r1cs_mp_ppzkpcd():
                 else:
                     tree_types[node_idx] = 1 + random.randint(0, RAND_MAX) % 2
             tree_elems[node_idx] = random.randint(0, RAND_MAX) % 100
-            tree_arity[node_idx] = 1 + (random.randint(0, RAND_MAX) % max_arity)
+            tree_arity[node_idx] = 1 + \
+                (random.randint(0, RAND_MAX) % max_arity)
             node_idx = node_idx + 1
         nodes_in_layer = nodes_in_layer * max_arity
-        
+
     tree_proofs = []
     tree_messages = []
     for i in range(tree_size):
         tree_proofs.append(0)
         tree_messages.append(0)
 
-    tally_1_accepted_types = {1,2}
+    tally_1_accepted_types = {1, 2}
     tally_2_accepted_types = {1}
-    tally_1 = pyzpk.tally_cp_handler(1, max_arity, wordsize, test_same_type_optimization, tally_1_accepted_types)
-    tally_2 = pyzpk.tally_cp_handler(2, max_arity, wordsize, test_same_type_optimization, tally_2_accepted_types)
+    tally_1 = pyzpk.tally_cp_handler(
+        1, max_arity, wordsize, test_same_type_optimization, tally_1_accepted_types)
+    tally_2 = pyzpk.tally_cp_handler(
+        2, max_arity, wordsize, test_same_type_optimization, tally_2_accepted_types)
     tally_1.generate_r1cs_constraints()
     tally_2.generate_r1cs_constraints()
     cp_1 = tally_1.get_compliance_predicate()
     cp_2 = tally_2.get_compliance_predicate()
 
-    nodes_in_layer =  nodes_in_layer//max_arity
+    nodes_in_layer = nodes_in_layer//max_arity
     layer = depth
     while layer >= 0:
         for i in range(0, nodes_in_layer+1):
@@ -85,13 +92,14 @@ def test_r1cs_mp_ppzkpcd():
             proofs = []
             if not base_case:
                 for i in range(0, max_arity):
-                    proofs.append(tree_proofs[max_arity*cur_idx + i + 1])   
+                    proofs.append(tree_proofs[max_arity*cur_idx + i + 1])
         layer = layer - 1
         nodes_in_layer = nodes_in_layer//max_arity
-        
+
+
 def test_r1cs_sp_ppzkpcd():
     max_arity = 2
-    depth = 2 #max_layer
+    depth = 2  # max_layer
     wordsize = 32
     test_serialization = True
     all_accept = True
@@ -114,9 +122,20 @@ def test_r1cs_sp_ppzkpcd():
         tree_messages.append(0)
 
     type = 1
-    tally_accepted_types = {1,2}
+    tally_accepted_types = {1, 2}
     test_same_type_optimization = True
-    tally = pyzpk.tally_cp_handler(type, max_arity, wordsize, test_same_type_optimization, tally_accepted_types)
+    tally = pyzpk.tally_cp_handler(
+        type, max_arity, wordsize, test_same_type_optimization, tally_accepted_types)
     tally.generate_r1cs_constraints()
     tally_cp = tally.get_compliance_predicate()
-    nodes_in_layer =  nodes_in_layer//max_arity
+    nodes_in_layer = nodes_in_layer//max_arity
+
+
+def test_r1cs_ppzkadsnark():
+    test_serialization = True
+    auth_keys = pyzpk.r1cs_ppzkadsnark_auth_keys()
+    keypair = pyzpk.r1cs_ppzkadsnark_auth_keys()
+    pvk = pyzpk.r1cs_ppzkadsnark_processed_verification_key()
+    labels = []
+    for i in range(10):
+        labels.append(pyzpk.labelT())


### PR DESCRIPTION
## Description
This PR adds bindings for r1cs ppzkadsnark (zk_proof_systems)

closes #45 
## How has this been tested?
- This can be tested by running `pytest test` from the root folder.


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
