### PR TITLE
Add Bindings for r1cs se ppzksnark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,8 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/pcd/r1cs_pcd/r1cs_sp_ppzkpcd/run_r1cs_sp_ppzkpcd.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzkadsnark/r1cs_ppzkadsnark/r1cs_ppzkadsnark_params_prf_signature.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/run_r1cs_se_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -87,6 +87,8 @@ void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_sp_pcd_circuits(py::modu
 void init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_run_r1cs_sp_ppzkpcd(py::module &);
 void init_zk_proof_systems_ppzkadsnark_r1cs_ppzkadsnark_r1cs_ppzkadsnark(py::module &);
 void init_zk_proof_systems_ppzkadsnark_r1cs_ppzkadsnark_params_prf_signature(py::module &);
+void init_zk_proof_systems_ppzksnark_r1cs_se_ppzksnark_r1cs_se_ppzksnark(py::module &);
+void init_zk_proof_systems_ppzksnark_r1cs_se_ppzksnark_run_r1cs_se_ppzksnark(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -178,4 +180,6 @@ PYBIND11_MODULE(pyzpk, m)
     init_zk_proof_systems_pcd_r1cs_pcd_r1cs_sp_ppzkpcd_run_r1cs_sp_ppzkpcd(m);
     init_zk_proof_systems_ppzkadsnark_r1cs_ppzkadsnark_r1cs_ppzkadsnark(m);
     init_zk_proof_systems_ppzkadsnark_r1cs_ppzkadsnark_params_prf_signature(m);
+    init_zk_proof_systems_ppzksnark_r1cs_se_ppzksnark_r1cs_se_ppzksnark(m);
+    init_zk_proof_systems_ppzksnark_r1cs_se_ppzksnark_run_r1cs_se_ppzksnark(m);
 }

--- a/src/PyZPK/relations/constraint_satisfaction_problems/r1cs/r1cs_examples.cpp
+++ b/src/PyZPK/relations/constraint_satisfaction_problems/r1cs/r1cs_examples.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
+#include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 #include <libsnark/relations/constraint_satisfaction_problems/r1cs/examples/r1cs_examples.hpp>
 
 namespace py = pybind11;
@@ -22,4 +23,7 @@ void init_relations_constraint_satisfaction_problems_r1cs_examples(py::module &m
 
     m.def("generate_r1cs_example_with_field_input", &generate_r1cs_example_with_field_input<FieldT>, py::arg("num_constraints"), py::arg("num_inputs"));
     m.def("generate_r1cs_example_with_binary_input", &generate_r1cs_example_with_binary_input<FieldT>, py::arg("num_constraints"), py::arg("num_inputs"));
+    
+    using FieldTbn = Fp_model<4l, libff::alt_bn128_modulus_r>;
+    m.def("generate_r1cs_example_with_binary_input_se_ppzksnark_pp", &generate_r1cs_example_with_binary_input<FieldTbn>);
 }

--- a/src/PyZPK/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.cpp
@@ -1,0 +1,241 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/r1cs_se_ppzksnark_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/r1cs_se_ppzksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for a SEppzkSNARK for R1CS.
+//  This includes:
+//  - class for proving key
+//  - class for verification key
+//  - class for processed verification key
+//  - class for key pair (proving key & verification key)
+//  - class for proof
+//  - generator algorithm
+//  - prover algorithm
+//  - verifier algorithm (with strong or weak input consistency)
+//  - online verifier algorithm (with strong or weak input consistency)
+
+// SEppzkSNARK = "Simulation-Extractable PreProcessing Zero-Knowledge Succinct
+//      Non-interactive ARgument of Knowledge"
+
+void declare_r1cs_se_ppzksnark_proving_key(py::module &m)
+{
+    // A proving key for the R1CS SEppzkSNARK.
+    using ppT = default_r1cs_se_ppzksnark_pp;
+
+    py::class_<r1cs_se_ppzksnark_proving_key<ppT>>(m, "r1cs_se_ppzksnark_proving_key")
+        .def(py::init<>())
+        .def(py::init<const r1cs_se_ppzksnark_proving_key<ppT> &>())
+        .def("G1_size", &r1cs_se_ppzksnark_proving_key<ppT>::G1_size)
+        .def("G2_size", &r1cs_se_ppzksnark_proving_key<ppT>::G2_size)
+        .def("size_in_bits", &r1cs_se_ppzksnark_proving_key<ppT>::size_in_bits)
+        .def("print_size", &r1cs_se_ppzksnark_proving_key<ppT>::print_size)
+        .def(
+            "__eq__", [](r1cs_se_ppzksnark_proving_key<ppT> const &self, r1cs_se_ppzksnark_proving_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_se_ppzksnark_proving_key<ppT> const &self) {
+        std::ostringstream os;
+        os << self.A_query;
+        os << self.B_query;
+        os << self.C_query_1;
+        os << self.C_query_2;
+        os << self.G_gamma_Z;
+        os << self.H_gamma_Z;
+        os << self.G_ab_gamma_Z;
+        os << self.G_gamma2_Z2;
+        os << self.G_gamma2_Z_t;
+        os << self.constraint_system;
+        return os;
+            })
+        .def("__istr__", [](r1cs_se_ppzksnark_proving_key<ppT> &self) {
+                std::istringstream in;
+                in >> self.A_query;
+                in >> self.B_query;
+                in >> self.C_query_1;
+                in >> self.C_query_2;
+                in >> self.G_gamma_Z;
+                in >> self.H_gamma_Z;
+                in >> self.G_ab_gamma_Z;
+                in >> self.G_gamma2_Z2;
+                in >> self.G_gamma2_Z_t;
+                in >> self.constraint_system;
+                return in;
+            });
+}
+
+void declare_r1cs_se_ppzksnark_verification_key(py::module &m)
+{
+    // A verification key for the R1CS SEppzkSNARK.
+    using ppT = default_r1cs_se_ppzksnark_pp;
+
+    py::class_<r1cs_se_ppzksnark_verification_key<ppT>>(m, "r1cs_se_ppzksnark_verification_key")
+        .def(py::init<>())
+        .def(py::init<const libff::G2<ppT> &,
+            const libff::G1<ppT> &,
+            const libff::G2<ppT> &,
+            const libff::G1<ppT> &,
+            const libff::G2<ppT> &,
+            libff::G1_vector<ppT> &&>())
+        .def("G1_size", &r1cs_se_ppzksnark_verification_key<ppT>::G1_size)
+        .def("G2_size", &r1cs_se_ppzksnark_verification_key<ppT>::G2_size)
+        .def("size_in_bits", &r1cs_se_ppzksnark_verification_key<ppT>::size_in_bits)
+        .def("print_size", &r1cs_se_ppzksnark_verification_key<ppT>::print_size)
+        .def(
+            "__eq__", [](r1cs_se_ppzksnark_verification_key<ppT> const &self, r1cs_se_ppzksnark_verification_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_se_ppzksnark_verification_key<ppT> const &self) {
+        std::ostringstream os;
+        os << self.H << OUTPUT_NEWLINE;
+        os << self.G_alpha << OUTPUT_NEWLINE;
+        os << self.H_beta << OUTPUT_NEWLINE;
+        os << self.G_gamma << OUTPUT_NEWLINE;
+        os << self.H_gamma << OUTPUT_NEWLINE;
+        os << self.query << OUTPUT_NEWLINE;
+        return os;
+            })
+        .def("__istr__", [](r1cs_se_ppzksnark_verification_key<ppT> &self) {
+                std::istringstream in;
+                in >> self.H;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.G_alpha;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.H_beta;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.G_gamma;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.H_gamma;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.query;
+                libff::consume_OUTPUT_NEWLINE(in);
+                return in;
+            });
+}
+
+void declare_r1cs_se_ppzksnark_processed_verification_key(py::module &m)
+{
+    // A processed verification key for the R1CS SEppzkSNARK.
+    using ppT = default_r1cs_se_ppzksnark_pp;
+
+    py::class_<r1cs_se_ppzksnark_processed_verification_key<ppT>>(m, "r1cs_se_ppzksnark_processed_verification_key")
+        .def(py::init<>())
+        .def(
+            "__eq__", [](r1cs_se_ppzksnark_processed_verification_key<ppT> const &self, r1cs_se_ppzksnark_processed_verification_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_se_ppzksnark_processed_verification_key<ppT> const &self) {
+        std::ostringstream os;
+        os << self.G_alpha << OUTPUT_NEWLINE;
+        os << self.H_beta << OUTPUT_NEWLINE;
+        os << self.G_alpha_H_beta_ml << OUTPUT_NEWLINE;
+        os << self.G_gamma_pc << OUTPUT_NEWLINE;
+        os << self.H_gamma_pc << OUTPUT_NEWLINE;
+        os << self.H_pc << OUTPUT_NEWLINE;
+        os << self.query << OUTPUT_NEWLINE;
+        return os;
+            })
+        .def("__istr__", [](r1cs_se_ppzksnark_processed_verification_key<ppT> &self) {
+                std::istringstream in;
+                in >> self.G_alpha;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.H_beta;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.G_alpha_H_beta_ml;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.G_gamma_pc;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.H_gamma_pc;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.H_pc;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.query;
+                libff::consume_OUTPUT_NEWLINE(in);
+                return in;
+            });
+}
+
+void declare_r1cs_se_ppzksnark_keypair(py::module &m)
+{
+    // A key pair for the R1CS SEppzkSNARK, which consists of a proving key and a verification key.
+    using ppT = default_r1cs_se_ppzksnark_pp;
+
+    py::class_<r1cs_se_ppzksnark_keypair<ppT>>(m, "r1cs_se_ppzksnark_keypair")
+        .def(py::init<>())
+        .def(py::init<const r1cs_se_ppzksnark_keypair<ppT> &>());
+}
+
+void declare_r1cs_se_ppzksnark_proof(py::module &m)
+{
+    // A verification key for the R1CS SEppzkSNARK.
+    using ppT = default_r1cs_se_ppzksnark_pp;
+
+    py::class_<r1cs_se_ppzksnark_proof<ppT>>(m, "r1cs_se_ppzksnark_proof")
+        .def(py::init<>())
+        .def("G1_size", &r1cs_se_ppzksnark_proof<ppT>::G1_size)
+        .def("G2_size", &r1cs_se_ppzksnark_proof<ppT>::G2_size)
+        .def("size_in_bits", &r1cs_se_ppzksnark_proof<ppT>::size_in_bits)
+        .def("print_size", &r1cs_se_ppzksnark_proof<ppT>::print_size)
+        .def("is_well_formed", &r1cs_se_ppzksnark_proof<ppT>::is_well_formed)
+        .def(
+            "__eq__", [](r1cs_se_ppzksnark_proof<ppT> const &self, r1cs_se_ppzksnark_proof<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](r1cs_se_ppzksnark_proof<ppT> const &self) {
+        std::ostringstream os;
+        os << self.A << OUTPUT_NEWLINE;
+        os << self.B << OUTPUT_NEWLINE;
+        os << self.C << OUTPUT_NEWLINE;
+        return os;
+            })
+        .def("__istr__", [](r1cs_se_ppzksnark_proof<ppT> &self) {
+                std::istringstream in;
+                in >> self.A;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.B;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> self.C;
+                libff::consume_OUTPUT_NEWLINE(in);
+                return in;
+            });
+}
+
+void declare_r1cs_se_Main_Algorithms(py::module &m)
+{
+    using ppT = default_r1cs_se_ppzksnark_pp;
+
+    // A generator algorithm for the R1CS SEppzkSNARK.
+    m.def("r1cs_se_ppzksnark_generator", &r1cs_se_ppzksnark_generator<ppT>);
+
+    // A prover algorithm for the R1CS SEppzkSNARK.
+    m.def("r1cs_se_ppzksnark_prover", &r1cs_se_ppzksnark_prover<ppT>);
+
+    // A verifier algorithm for the R1CS SEppzkSNARK that:
+    //(1) accepts a non-processed verification key, and
+    //(2) has weak input consistency.
+    m.def("r1cs_se_ppzksnark_verifier_weak_IC", &r1cs_se_ppzksnark_verifier_weak_IC<ppT>);
+
+    // A verifier algorithm for the R1CS SEppzkSNARK that:
+    //(1) accepts a non-processed verification key, and
+    //(2) has strong input consistency.
+    m.def("r1cs_se_ppzksnark_verifier_strong_IC", &r1cs_se_ppzksnark_verifier_strong_IC<ppT>);
+
+    // Convert a (non-processed) verification key into a processed verification key.
+    m.def("r1cs_se_ppzksnark_online_verifier_weak_IC", &r1cs_se_ppzksnark_online_verifier_weak_IC<ppT>);
+
+    // A verifier algorithm for the R1CS ppzkSNARK that:
+    //(1) accepts a processed verification key, and
+    //(2) has weak input consistency.
+    m.def("r1cs_se_ppzksnark_verifier_process_vk", &r1cs_se_ppzksnark_verifier_process_vk<ppT>);
+
+    // A verifier algorithm for the R1CS ppzkSNARK that:
+    //(1) accepts a processed verification key, and
+    //(2) has strong input consistency.
+    m.def("r1cs_se_ppzksnark_online_verifier_strong_IC", &r1cs_se_ppzksnark_online_verifier_strong_IC<ppT>);
+}
+
+void init_zk_proof_systems_ppzksnark_r1cs_se_ppzksnark_r1cs_se_ppzksnark(py::module &m)
+{
+    declare_r1cs_se_ppzksnark_proving_key(m);
+    declare_r1cs_se_ppzksnark_verification_key(m);
+    declare_r1cs_se_ppzksnark_processed_verification_key(m);
+    declare_r1cs_se_ppzksnark_keypair(m);
+    declare_r1cs_se_ppzksnark_proof(m);
+    declare_r1cs_se_Main_Algorithms(m);
+}

--- a/src/PyZPK/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/run_r1cs_se_ppzksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/run_r1cs_se_ppzksnark.cpp
@@ -1,0 +1,21 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/r1cs_se_ppzksnark_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_se_ppzksnark/examples/run_r1cs_se_ppzksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Declaration of functionality that runs the R1CS SEppzkSNARK for
+// a given R1CS example.
+
+void init_zk_proof_systems_ppzksnark_r1cs_se_ppzksnark_run_r1cs_se_ppzksnark(py::module &m)
+{
+    // Runs the SEppzkSNARK(generator, prover, and verifier) for a given
+    // R1CS example(specified by a constraint system, input, and witness).
+
+    using ppT = default_r1cs_se_ppzksnark_pp;
+
+    m.def("run_r1cs_se_ppzksnark", &run_r1cs_se_ppzksnark<ppT>);
+}

--- a/test/test_zk_proof_systems.py
+++ b/test/test_zk_proof_systems.py
@@ -139,3 +139,10 @@ def test_r1cs_ppzkadsnark():
     labels = []
     for i in range(10):
         labels.append(pyzpk.labelT())
+
+def test_se_ppzksnark():
+    num_constraints = 1000
+    input_size = 100
+    test_serialization = True
+    example = pyzpk.generate_r1cs_example_with_binary_input(num_constraints, input_size)
+    assert(example)


### PR DESCRIPTION
## Description
This PR adds bindings for r1cs se ppzksnark (zk_proof_systems)

closes #46 
## How has this been tested?
- This can be tested by running `pytest test` from the root folder.


## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
