### PR TITLE
 Add Bindings for uscs ppzksnark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,8 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/run_r1cs_gg_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/bacs_ppzksnark/bacs_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/bacs_ppzksnark/run_bacs_ppzksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/uscs_ppzksnark/run_uscs_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -93,6 +93,8 @@ void init_zk_proof_systems_ppzksnark_r1cs_gg_ppzksnark_r1cs_gg_ppzksnark(py::mod
 void init_zk_proof_systems_ppzksnark_r1cs_gg_ppzksnark_run_r1cs_gg_ppzksnark(py::module &);
 void init_zk_proof_systems_ppzksnark_bacs_ppzksnark_bacs_ppzksnark(py::module &);
 void init_zk_proof_systems_ppzksnark_bacs_ppzksnark_run_bacs_ppzksnark(py::module &);
+void init_zk_proof_systems_ppzksnark_uscs_ppzksnark_uscs_ppzksnark(py::module &);
+void init_zk_proof_systems_ppzksnark_uscs_ppzksnark_run_uscs_ppzksnark(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -190,4 +192,6 @@ PYBIND11_MODULE(pyzpk, m)
     init_zk_proof_systems_ppzksnark_r1cs_gg_ppzksnark_run_r1cs_gg_ppzksnark(m);
     init_zk_proof_systems_ppzksnark_bacs_ppzksnark_bacs_ppzksnark(m);
     init_zk_proof_systems_ppzksnark_bacs_ppzksnark_run_bacs_ppzksnark(m);
+    init_zk_proof_systems_ppzksnark_uscs_ppzksnark_uscs_ppzksnark(m);
+    init_zk_proof_systems_ppzksnark_uscs_ppzksnark_run_uscs_ppzksnark(m);
 }

--- a/src/PyZPK/zk_proof_systems/ppzksnark/uscs_ppzksnark/run_uscs_ppzksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzksnark/uscs_ppzksnark/run_uscs_ppzksnark.cpp
@@ -1,0 +1,19 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/uscs_ppzksnark_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/examples/run_uscs_ppzksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//  Declaration of functionality that runs the USCS ppzkSNARK for
+//  a given USCS example.
+void init_zk_proof_systems_ppzksnark_uscs_ppzksnark_run_uscs_ppzksnark(py::module &m)
+{
+    // Runs the ppzkSNARK (generator, prover, and verifier) for a given
+    // USCS example (specified by a circuit, primary input, and auxiliary input).
+
+    using ppT = default_uscs_ppzksnark_pp;
+    m.def("run_uscs_ppzksnark", &run_uscs_ppzksnark<ppT>);
+}

--- a/src/PyZPK/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.cpp
@@ -1,0 +1,228 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/uscs_ppzksnark_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for a ppzkSNARK for USCS.
+
+//  This includes:
+//  - class for proving key
+//  - class for verification key
+//  - class for processed verification key
+//  - class for key pair (proving key & verification key)
+//  - class for proof
+//  - generator algorithm
+//  - prover algorithm
+//  - verifier algorithm (with strong or weak input consistency)
+//  - online verifier algorithm (with strong or weak input consistency)
+
+void declare_uscs_ppzksnark_proving_key(py::module &m)
+{
+    // A proving key for the USCS ppzkSNARK.
+    using ppT = default_uscs_ppzksnark_pp;
+
+    py::class_<uscs_ppzksnark_proving_key<ppT>>(m, "uscs_ppzksnark_proving_key")
+        .def(py::init<>())
+        .def(py::init<const uscs_ppzksnark_proving_key<ppT> &>())
+        .def("G1_size", &uscs_ppzksnark_proving_key<ppT>::G1_size)
+        .def("G2_size", &uscs_ppzksnark_proving_key<ppT>::G2_size)
+        .def("G1_sparse_size", &uscs_ppzksnark_proving_key<ppT>::G1_sparse_size)
+        .def("G2_sparse_size", &uscs_ppzksnark_proving_key<ppT>::G2_sparse_size)
+        .def("size_in_bits", &uscs_ppzksnark_proving_key<ppT>::size_in_bits)
+        .def("print_size", &uscs_ppzksnark_proving_key<ppT>::print_size)
+        .def(
+            "__eq__", [](uscs_ppzksnark_proving_key<ppT> const &self, uscs_ppzksnark_proving_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](uscs_ppzksnark_proving_key<ppT> const &pk) {
+        std::ostringstream os;
+        os << pk.V_g1_query;
+        os << pk.alpha_V_g1_query;
+        os << pk.H_g1_query;
+        os << pk.V_g2_query;
+        os << pk.constraint_system;
+        return os;
+            })
+        .def("__istr__", [](uscs_ppzksnark_proving_key<ppT> &pk) {
+                std::istringstream in;
+                in >> pk.V_g1_query;
+                in >> pk.alpha_V_g1_query;
+                in >> pk.H_g1_query;
+                in >> pk.V_g2_query;
+                in >> pk.constraint_system;
+                return in;
+            });
+}
+
+void declare_uscs_ppzksnark_verification_key(py::module &m)
+{
+    // A verification key for the USCS ppzkSNARK.
+    using ppT = default_uscs_ppzksnark_pp;
+
+    py::class_<uscs_ppzksnark_verification_key<ppT>>(m, "uscs_ppzksnark_verification_key")
+        .def(py::init<>())
+        .def(py::init<const libff::G2<ppT> &,
+            const libff::G2<ppT> &,
+            const libff::G2<ppT> &,
+            const accumulation_vector<libff::G1<ppT>> &>())
+        .def("G1_size", &uscs_ppzksnark_verification_key<ppT>::G1_size)
+        .def("G2_size", &uscs_ppzksnark_verification_key<ppT>::G2_size)
+        .def("size_in_bits", &uscs_ppzksnark_verification_key<ppT>::size_in_bits)
+        .def("print_size", &uscs_ppzksnark_verification_key<ppT>::print_size)
+        .def(
+            "__eq__", [](uscs_ppzksnark_verification_key<ppT> const &self, uscs_ppzksnark_verification_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](uscs_ppzksnark_verification_key<ppT> const &vk) {
+        std::ostringstream os;
+        os << vk.tilde_g2 << OUTPUT_NEWLINE;
+        os << vk.alpha_tilde_g2 << OUTPUT_NEWLINE;
+        os << vk.Z_g2 << OUTPUT_NEWLINE;
+        os << vk.encoded_IC_query << OUTPUT_NEWLINE;
+        return os;
+            })
+        .def("__istr__", [](uscs_ppzksnark_verification_key<ppT> &vk) {
+                std::istringstream in;
+                in >> vk.tilde_g2;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> vk.alpha_tilde_g2;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> vk.Z_g2;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> vk.encoded_IC_query;
+                libff::consume_OUTPUT_NEWLINE(in);
+                return in;
+            });
+}
+
+void declare_uscs_ppzksnark_processed_verification_key(py::module &m)
+{
+    // A verification key for the USCS ppzkSNARK.
+    using ppT = default_uscs_ppzksnark_pp;
+
+    py::class_<uscs_ppzksnark_processed_verification_key<ppT>>(m, "uscs_ppzksnark_processed_verification_key")
+        .def(py::init<>())
+        .def(
+            "__eq__", [](uscs_ppzksnark_processed_verification_key<ppT> const &self, uscs_ppzksnark_processed_verification_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](uscs_ppzksnark_processed_verification_key<ppT> const &pvk) {
+        std::ostringstream os;
+        os << pvk.pp_G1_one_precomp << OUTPUT_NEWLINE;
+        os << pvk.pp_G2_one_precomp << OUTPUT_NEWLINE;
+        os << pvk.vk_tilde_g2_precomp << OUTPUT_NEWLINE;
+        os << pvk.vk_alpha_tilde_g2_precomp << OUTPUT_NEWLINE;
+        os << pvk.vk_Z_g2_precomp << OUTPUT_NEWLINE;
+        os << pvk.pairing_of_g1_and_g2 << OUTPUT_NEWLINE;
+        os << pvk.encoded_IC_query << OUTPUT_NEWLINE;
+        return os;
+            })
+        .def("__istr__", [](uscs_ppzksnark_processed_verification_key<ppT> &pvk) {
+                std::istringstream in;
+                in >> pvk.pp_G1_one_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> pvk.pp_G2_one_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> pvk.vk_tilde_g2_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> pvk.vk_alpha_tilde_g2_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> pvk.vk_Z_g2_precomp;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> pvk.pairing_of_g1_and_g2;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> pvk.encoded_IC_query;
+                libff::consume_OUTPUT_NEWLINE(in);
+                return in;
+            });
+}
+
+void declare_uscs_ppzksnark_keypair(py::module &m)
+{
+    // A key pair for the USCS ppzkSNARK, which consists of a proving key and a verification key.
+    using ppT = default_uscs_ppzksnark_pp;
+
+    py::class_<uscs_ppzksnark_keypair<ppT>>(m, "uscs_ppzksnark_keypair")
+        .def(py::init<>());
+}
+
+void declare_uscs_ppzksnark_proof(py::module &m)
+{
+    // A verification key for the USCS ppzkSNARK.
+    using ppT = default_uscs_ppzksnark_pp;
+
+    py::class_<uscs_ppzksnark_proof<ppT>>(m, "uscs_ppzksnark_proof")
+        .def(py::init<>())
+        .def("G1_size", &uscs_ppzksnark_proof<ppT>::G1_size)
+        .def("G2_size", &uscs_ppzksnark_proof<ppT>::G2_size)
+        .def("size_in_bits", &uscs_ppzksnark_proof<ppT>::size_in_bits)
+        .def("print_size", &uscs_ppzksnark_proof<ppT>::print_size)
+        .def("is_well_formed", &uscs_ppzksnark_proof<ppT>::is_well_formed)
+        .def(
+            "__eq__", [](uscs_ppzksnark_proof<ppT> const &self, uscs_ppzksnark_proof<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](uscs_ppzksnark_proof<ppT> const &proof) {
+        std::ostringstream os;
+        os << proof.V_g1 << OUTPUT_NEWLINE;
+        os << proof.alpha_V_g1 << OUTPUT_NEWLINE;
+        os << proof.H_g1 << OUTPUT_NEWLINE;
+        os << proof.V_g2 << OUTPUT_NEWLINE;
+        return os;
+            })
+        .def("__istr__", [](uscs_ppzksnark_proof<ppT> &proof) {
+                std::istringstream in;
+                in >> proof.V_g1;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> proof.alpha_V_g1;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> proof.H_g1;
+                libff::consume_OUTPUT_NEWLINE(in);
+                in >> proof.V_g2;
+                libff::consume_OUTPUT_NEWLINE(in);
+
+                return in;
+            });
+}
+
+void declare_USCS_Main_Algorithms(py::module &m)
+{
+    using ppT = default_uscs_ppzksnark_pp;
+
+    // A generator algorithm for the USCS ppzkSNARK.
+    // Given a USCS constraint system CS, this algorithm produces proving and verification keys for CS.
+    m.def("uscs_ppzksnark_generator", &uscs_ppzksnark_generator<ppT>);
+
+    // A prover algorithm for the USCS ppzkSNARK.
+    m.def("uscs_ppzksnark_prover", &uscs_ppzksnark_prover<ppT>);
+
+    // A verifier algorithm for the USCS ppzkSNARK that:
+    //(1) accepts a non-processed verification key, and
+    //(2) has weak input consistency.
+    m.def("uscs_ppzksnark_verifier_weak_IC", &uscs_ppzksnark_verifier_weak_IC<ppT>);
+
+    //  A verifier algorithm for the USCS ppzkSNARK that:
+    //(1) accepts a non-processed verification key, and
+    //(2) has strong input consistency.
+    m.def("uscs_ppzksnark_verifier_strong_IC", &uscs_ppzksnark_verifier_strong_IC<ppT>);
+
+    // Convert a (non-processed) verification key into a processed verification key.
+    m.def("uscs_ppzksnark_verifier_process_vk", &uscs_ppzksnark_verifier_process_vk<ppT>);
+
+    // A verifier algorithm for the USCS ppzkSNARK that:
+    //(1) accepts a processed verification key, and
+    //(2) has weak input consistency.
+    m.def("uscs_ppzksnark_online_verifier_weak_IC", &uscs_ppzksnark_online_verifier_weak_IC<ppT>);
+
+    // A verifier algorithm for the USCS ppzkSNARK that:
+    //(1) accepts a processed verification key, and
+    //(2) has strong input consistency.
+    m.def("uscs_ppzksnark_online_verifier_strong_IC", &uscs_ppzksnark_online_verifier_strong_IC<ppT>);
+}
+
+
+void init_zk_proof_systems_ppzksnark_uscs_ppzksnark_uscs_ppzksnark(py::module &m)
+{
+    declare_uscs_ppzksnark_proving_key(m);
+    declare_uscs_ppzksnark_verification_key(m);
+    declare_uscs_ppzksnark_processed_verification_key(m);
+    declare_uscs_ppzksnark_keypair(m);
+    declare_uscs_ppzksnark_proof(m);
+    declare_USCS_Main_Algorithms(m);
+}

--- a/test/test_zk_proof_systems.py
+++ b/test/test_zk_proof_systems.py
@@ -140,13 +140,16 @@ def test_r1cs_ppzkadsnark():
     for i in range(10):
         labels.append(pyzpk.labelT())
 
+
 def test_se_and_gg_ppzksnark():
     num_constraints = 1000
     input_size = 100
     test_serialization = True
-    example = pyzpk.generate_r1cs_example_with_binary_input(num_constraints, input_size)
+    example = pyzpk.generate_r1cs_example_with_binary_input(
+        num_constraints, input_size)
     assert(example)
-    
+
+
 def test_bacs_ppzksnark():
     primary_input_size = 10
     auxiliary_input_size = 10
@@ -197,3 +200,11 @@ def test_bacs_ppzksnark():
 
     assert example.circuit.is_satisfied(
         primary_input_list, auxiliary_input_list)
+
+def test_uscs_ppzksnark():
+    num_constraints = 1000
+    input_size = 100
+    test_serialization = True
+    example = pyzpk.generate_uscs_example_with_binary_input(
+        num_constraints, input_size)
+    assert(example)


### PR DESCRIPTION
## Description
This PR adds bindings for USCS ppzksnark (zk_proof_systems)

closes #49 
## How has this been tested?
- This can be tested by running `pytest test` from the root folder.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
