### PR TITLE
 Add Bindings for ram ppzksnark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,6 +94,8 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/bacs_ppzksnark/run_bacs_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/uscs_ppzksnark/uscs_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/uscs_ppzksnark/run_uscs_ppzksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/ram_ppzksnark/run_ram_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -95,6 +95,8 @@ void init_zk_proof_systems_ppzksnark_bacs_ppzksnark_bacs_ppzksnark(py::module &)
 void init_zk_proof_systems_ppzksnark_bacs_ppzksnark_run_bacs_ppzksnark(py::module &);
 void init_zk_proof_systems_ppzksnark_uscs_ppzksnark_uscs_ppzksnark(py::module &);
 void init_zk_proof_systems_ppzksnark_uscs_ppzksnark_run_uscs_ppzksnark(py::module &);
+void init_zk_proof_systems_ppzksnark_ram_ppzksnark_ram_ppzksnark(py::module &);
+void init_zk_proof_systems_ppzksnark_ram_ppzksnark_run_ram_ppzksnark(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -194,4 +196,6 @@ PYBIND11_MODULE(pyzpk, m)
     init_zk_proof_systems_ppzksnark_bacs_ppzksnark_run_bacs_ppzksnark(m);
     init_zk_proof_systems_ppzksnark_uscs_ppzksnark_uscs_ppzksnark(m);
     init_zk_proof_systems_ppzksnark_uscs_ppzksnark_run_uscs_ppzksnark(m);
+    init_zk_proof_systems_ppzksnark_ram_ppzksnark_ram_ppzksnark(m);
+    init_zk_proof_systems_ppzksnark_ram_ppzksnark_run_ram_ppzksnark(m);
 }

--- a/src/PyZPK/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.cpp
@@ -1,0 +1,114 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/ram_ppzksnark_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark_params.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for a ppzkSNARK for RAM.
+
+//  This includes:
+//  - the class for a proving key;
+//  - the class for a verification key;
+//  - the class for a key pair (proving key & verification key);
+//  - the class for a proof;
+//  - the generator algorithm;
+//  - the prover algorithm;
+//  - the verifier algorithm.
+
+void declare_ram_ppzksnark_proving_key(py::module &m)
+{
+    // A proving key for the RAM ppzkSNARK.
+    using ppT = default_ram_ppzksnark_pp;
+
+    py::class_<ram_ppzksnark_proving_key<ppT>>(m, "ram_ppzksnark_proving_key")
+        .def(py::init<>())
+        .def(py::init<const ram_ppzksnark_proving_key<ppT> &>())
+        .def(
+            "__eq__", [](ram_ppzksnark_proving_key<ppT> const &self, ram_ppzksnark_proving_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](ram_ppzksnark_proving_key<ppT> const &pk) {
+            std::ostringstream os;
+            os << pk.r1cs_pk;
+            os << pk.ap;
+            os << pk.primary_input_size_bound << "\n";
+            os << pk.time_bound << "\n";
+            return os;
+        })
+        .def("__istr__", [](ram_ppzksnark_proving_key<ppT> &pk) {
+            std::istringstream in;
+            in >> pk.r1cs_pk;
+            in >> pk.ap;
+            in >> pk.primary_input_size_bound;
+            libff::consume_newline(in);
+            in >> pk.time_bound;
+            libff::consume_newline(in);
+            return in;
+        });
+}
+
+void declare_ram_ppzksnark_verification_key(py::module &m)
+{
+    // A verification key for the RAM ppzkSNARK.
+    using ppT = default_ram_ppzksnark_pp;
+
+    py::class_<ram_ppzksnark_verification_key<ppT>>(m, "ram_ppzksnark_verification_key")
+        .def(py::init<>())
+        .def(py::init<const ram_ppzksnark_verification_key<ppT> &>())
+        .def("bind_primary_input", &ram_ppzksnark_verification_key<ppT>::bind_primary_input)
+        .def(
+            "__eq__", [](ram_ppzksnark_verification_key<ppT> const &self, ram_ppzksnark_verification_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](ram_ppzksnark_verification_key<ppT> const &vk) {
+            std::ostringstream os;
+            os << vk.r1cs_vk;
+            os << vk.ap;
+            os << vk.primary_input_size_bound << "\n";
+            os << vk.time_bound << "\n";
+            return os;
+        })
+        .def("__istr__", [](ram_ppzksnark_verification_key<ppT> &vk) {
+            std::istringstream in;
+            in >> vk.r1cs_vk;
+            in >> vk.ap;
+            in >> vk.primary_input_size_bound;
+            libff::consume_newline(in);
+            in >> vk.time_bound;
+            libff::consume_newline(in);
+            return in;
+        });
+}
+
+void declare_ram_ppzksnark_keypair(py::module &m)
+{
+    // A key pair for the RAM ppzkSNARK, which consists of a proving key and a verification key.
+    using ppT = default_ram_ppzksnark_pp;
+
+    py::class_<ram_ppzksnark_keypair<ppT>>(m, "ram_ppzksnark_keypair")
+        .def(py::init<>())
+        .def(py::init<const ram_ppzksnark_keypair<ppT> &>());
+}
+
+
+void declare_RAM_Main_Algorithms(py::module &m)
+{
+    using ppT = default_ram_ppzksnark_pp;
+
+    //  A generator algorithm for the RAM ppzkSNARK.
+    m.def("ram_ppzksnark_generator", &ram_ppzksnark_generator<ppT>);
+
+    // A prover algorithm for the RAM ppzkSNARK.
+    m.def("ram_ppzksnark_prover", &ram_ppzksnark_prover<ppT>);
+
+    // A verifier algorithm for the RAM ppzkSNARK that:
+    m.def("ram_ppzksnark_verifier", &ram_ppzksnark_verifier<ppT>);
+}
+
+void init_zk_proof_systems_ppzksnark_ram_ppzksnark_ram_ppzksnark(py::module &m)
+{
+    declare_ram_ppzksnark_proving_key(m);
+    declare_ram_ppzksnark_verification_key(m);
+    declare_ram_ppzksnark_keypair(m);
+    declare_RAM_Main_Algorithms(m);
+}

--- a/src/PyZPK/zk_proof_systems/ppzksnark/ram_ppzksnark/run_ram_ppzksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzksnark/ram_ppzksnark/run_ram_ppzksnark.cpp
@@ -1,0 +1,18 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/ram_ppzksnark_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/ram_ppzksnark/examples/run_ram_ppzksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Declaration of functionality that runs the RAM ppzkSNARK for a given RAM example.
+void init_zk_proof_systems_ppzksnark_ram_ppzksnark_run_ram_ppzksnark(py::module &m)
+{
+    // Runs the ppzkSNARK (generator, prover, and verifier) for a given
+    // RAM example (specified by an architecture, boot trace, auxiliary input, and time bound).
+
+    using ppT = default_ram_ppzksnark_pp;
+    m.def("run_ram_ppzksnark", &run_ram_ppzksnark<ppT>);
+}

--- a/test/test_zk_proof_systems.py
+++ b/test/test_zk_proof_systems.py
@@ -208,3 +208,18 @@ def test_uscs_ppzksnark():
     example = pyzpk.generate_uscs_example_with_binary_input(
         num_constraints, input_size)
     assert(example)
+
+def test_ram_ppzksnark():
+    w = 16
+    k = 16
+    program_size = 16
+    input_size = 2
+    time_bound = 20
+    boot_trace_size_bound = program_size + input_size
+    satisfiable = True
+    program_size = boot_trace_size_bound / 2
+    input_size = boot_trace_size_bound - program_size
+
+    assert 2*w/8*program_size < 1<<(w-1)
+    assert w/8*input_size < 1<<(w-1)
+    assert input_size >= 1


### PR DESCRIPTION
## Description
This PR adds bindings for ram ppzksnark (zk_proof_systems)

closes #50 
## How has this been tested?
- This can be tested by running `pytest test` from the root folder.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
