### PR TITLE
Add Bindings for tbcs ppzksnark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,8 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/uscs_ppzksnark/run_uscs_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/ram_ppzksnark/ram_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/ram_ppzksnark/run_ram_ppzksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/tbcs_ppzksnark/run_tbcs_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -97,6 +97,8 @@ void init_zk_proof_systems_ppzksnark_uscs_ppzksnark_uscs_ppzksnark(py::module &)
 void init_zk_proof_systems_ppzksnark_uscs_ppzksnark_run_uscs_ppzksnark(py::module &);
 void init_zk_proof_systems_ppzksnark_ram_ppzksnark_ram_ppzksnark(py::module &);
 void init_zk_proof_systems_ppzksnark_ram_ppzksnark_run_ram_ppzksnark(py::module &);
+void init_zk_proof_systems_ppzksnark_tbcs_ppzksnark_tbcs_ppzksnark(py::module &);
+void init_zk_proof_systems_ppzksnark_tbcs_ppzksnark_run_tbcs_ppzksnark(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -198,4 +200,6 @@ PYBIND11_MODULE(pyzpk, m)
     init_zk_proof_systems_ppzksnark_uscs_ppzksnark_run_uscs_ppzksnark(m);
     init_zk_proof_systems_ppzksnark_ram_ppzksnark_ram_ppzksnark(m);
     init_zk_proof_systems_ppzksnark_ram_ppzksnark_run_ram_ppzksnark(m);
+    init_zk_proof_systems_ppzksnark_tbcs_ppzksnark_tbcs_ppzksnark(m);
+    init_zk_proof_systems_ppzksnark_tbcs_ppzksnark_run_tbcs_ppzksnark(m);
 }

--- a/src/PyZPK/zk_proof_systems/ppzksnark/tbcs_ppzksnark/run_tbcs_ppzksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzksnark/tbcs_ppzksnark/run_tbcs_ppzksnark.cpp
@@ -1,0 +1,18 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/tbcs_ppzksnark_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/tbcs_ppzksnark/examples/run_tbcs_ppzksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Declaration of functionality that runs the TBCS ppzkSNARK for a given TBCS example.
+void init_zk_proof_systems_ppzksnark_tbcs_ppzksnark_run_tbcs_ppzksnark(py::module &m)
+{
+    // Runs the ppzkSNARK (generator, prover, and verifier) for a given
+    // TBCS example (specified by an architecture, boot trace, auxiliary input, and time bound).
+
+    using ppT = default_tbcs_ppzksnark_pp;
+    m.def("run_tbcs_ppzksnark", &run_tbcs_ppzksnark<ppT>);
+}

--- a/src/PyZPK/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.cpp
@@ -1,0 +1,107 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/tbcs_ppzksnark_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+// Interfaces for a ppzkSNARK for TBCS.
+//  This includes:
+//  - class for proving key
+//  - class for verification key
+//  - class for processed verification key
+//  - class for key pair (proving key & verification key)
+//  - class for proof
+//  - generator algorithm
+//  - prover algorithm
+//  - verifier algorithm (with strong or weak input consistency)
+//  - online verifier algorithm (with strong or weak input consistency)
+
+void declare_tbcs_ppzksnark_proving_key(py::module &m)
+{
+    // A proving key for the TBCS ppzkSNARK.
+    using ppT = default_tbcs_ppzksnark_pp;
+
+    py::class_<tbcs_ppzksnark_proving_key<ppT>>(m, "tbcs_ppzksnark_proving_key")
+        .def(py::init<>())
+        .def(py::init<const tbcs_ppzksnark_proving_key<ppT> &>())
+        .def(py::init<const tbcs_ppzksnark_circuit &,
+                      const uscs_ppzksnark_proving_key<ppT> &>())
+        .def("G1_size", &tbcs_ppzksnark_proving_key<ppT>::G1_size)
+        .def("G2_size", &tbcs_ppzksnark_proving_key<ppT>::G2_size)
+        .def("G1_sparse_size", &tbcs_ppzksnark_proving_key<ppT>::G1_sparse_size)
+        .def("G2_sparse_size", &tbcs_ppzksnark_proving_key<ppT>::G2_sparse_size)
+        .def("size_in_bits", &tbcs_ppzksnark_proving_key<ppT>::size_in_bits)
+        .def("print_size", &tbcs_ppzksnark_proving_key<ppT>::print_size)
+        .def(
+            "__eq__", [](tbcs_ppzksnark_proving_key<ppT> const &self, tbcs_ppzksnark_proving_key<ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](tbcs_ppzksnark_proving_key<ppT> const &pk) {
+            std::ostringstream os;
+            os << pk.circuit << OUTPUT_NEWLINE;
+            os << pk.uscs_pk << OUTPUT_NEWLINE;
+            return os;
+        })
+        .def("__istr__", [](tbcs_ppzksnark_proving_key<ppT> &pk) {
+            std::istringstream in;
+            in >> pk.circuit;
+            libff::consume_OUTPUT_NEWLINE(in);
+            in >> pk.uscs_pk;
+            libff::consume_OUTPUT_NEWLINE(in);
+            return in;
+        });
+}
+
+void declare_tbcs_ppzksnark_keypair(py::module &m)
+{
+    // A key pair for the TBCS ppzkSNARK, which consists of a proving key and a verification key.
+    using ppT = default_tbcs_ppzksnark_pp;
+
+    py::class_<tbcs_ppzksnark_keypair<ppT>>(m, "tbcs_ppzksnark_keypair")
+        .def(py::init<>())
+        .def(py::init<const tbcs_ppzksnark_proving_key<ppT> &,
+                      const tbcs_ppzksnark_verification_key<ppT> &>());
+}
+
+void declare_TBCS_Main_Algorithms(py::module &m)
+{
+    using ppT = default_tbcs_ppzksnark_pp;
+
+    // A generator algorithm for the TBCS ppzkSNARK.
+    // Given a TBCS constraint system CS, this algorithm produces proving and verification keys for CS.
+    m.def("tbcs_ppzksnark_generator", &tbcs_ppzksnark_generator<ppT>);
+
+    // A prover algorithm for the TBCS ppzkSNARK.
+    m.def("tbcs_ppzksnark_prover", &tbcs_ppzksnark_prover<ppT>);
+
+    // A verifier algorithm for the TBCS ppzkSNARK that:
+    //(1) accepts a non-processed verification key, and
+    //(2) has weak input consistency.
+    m.def("tbcs_ppzksnark_verifier_weak_IC", &tbcs_ppzksnark_verifier_weak_IC<ppT>);
+
+    //  A verifier algorithm for the TBCS ppzkSNARK that:
+    //(1) accepts a non-processed verification key, and
+    //(2) has strong input consistency.
+    m.def("tbcs_ppzksnark_verifier_strong_IC", &tbcs_ppzksnark_verifier_strong_IC<ppT>);
+
+    // Convert a (non-processed) verification key into a processed verification key.
+    m.def("tbcs_ppzksnark_verifier_process_vk", &tbcs_ppzksnark_verifier_process_vk<ppT>);
+
+    // A verifier algorithm for the TBCS ppzkSNARK that:
+    //(1) accepts a processed verification key, and
+    //(2) has weak input consistency.
+    m.def("tbcs_ppzksnark_online_verifier_weak_IC", &tbcs_ppzksnark_online_verifier_weak_IC<ppT>);
+
+    // A verifier algorithm for the TBCS ppzkSNARK that:
+    //(1) accepts a processed verification key, and
+    //(2) has strong input consistency.
+    m.def("tbcs_ppzksnark_online_verifier_strong_IC", &tbcs_ppzksnark_online_verifier_strong_IC<ppT>);
+}
+
+void init_zk_proof_systems_ppzksnark_tbcs_ppzksnark_tbcs_ppzksnark(py::module &m)
+{
+    declare_tbcs_ppzksnark_proving_key(m);
+    declare_tbcs_ppzksnark_keypair(m);
+    declare_TBCS_Main_Algorithms(m);
+}


### PR DESCRIPTION
## Description
This PR adds bindings for tbcs ppzksnark (zk_proof_systems)

closes #51 
## How has this been tested?
- This can be tested by running `pytest test` from the root folder.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
