### PR TITLE
Add Bindings for RAM zksnark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,8 @@ set(
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/ram_ppzksnark/run_ram_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/tbcs_ppzksnark/tbcs_ppzksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/ppzksnark/tbcs_ppzksnark/run_tbcs_ppzksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/zk_proof_systems/zksnark/ram_zksnark/run_ram_zksnark.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/PyZPK/binding.cpp"
 )
 

--- a/src/PyZPK/binding.cpp
+++ b/src/PyZPK/binding.cpp
@@ -99,6 +99,8 @@ void init_zk_proof_systems_ppzksnark_ram_ppzksnark_ram_ppzksnark(py::module &);
 void init_zk_proof_systems_ppzksnark_ram_ppzksnark_run_ram_ppzksnark(py::module &);
 void init_zk_proof_systems_ppzksnark_tbcs_ppzksnark_tbcs_ppzksnark(py::module &);
 void init_zk_proof_systems_ppzksnark_tbcs_ppzksnark_run_tbcs_ppzksnark(py::module &);
+void init_zk_proof_systems_zksnark_ram_zksnark_ram_zksnark(py::module &);
+void init_zk_proof_systems_ppzksnark_ram_zksnark_run_ram_zksnark(py::module &);
 
 PYBIND11_MODULE(pyzpk, m)
 {
@@ -202,4 +204,6 @@ PYBIND11_MODULE(pyzpk, m)
     init_zk_proof_systems_ppzksnark_ram_ppzksnark_run_ram_ppzksnark(m);
     init_zk_proof_systems_ppzksnark_tbcs_ppzksnark_tbcs_ppzksnark(m);
     init_zk_proof_systems_ppzksnark_tbcs_ppzksnark_run_tbcs_ppzksnark(m);
+    init_zk_proof_systems_zksnark_ram_zksnark_ram_zksnark(m);
+    init_zk_proof_systems_ppzksnark_ram_zksnark_run_ram_zksnark(m);
 }

--- a/src/PyZPK/zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.cpp
@@ -1,0 +1,123 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/ram_zksnark_pp.hpp>
+#include <libsnark/zk_proof_systems/zksnark/ram_zksnark/ram_zksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//  Interfaces for a zkSNARK for RAM.
+//  This includes:
+//  - the class for a proving key;
+//  - the class for a verification key;
+//  - the class for a key pair (proving key & verification key);
+//  - the class for a proof;
+//  - the generator algorithm;
+//  - the prover algorithm;
+//  - the verifier algorithm.
+
+void declare_ram_zksnark_proving_key(py::module &m)
+{
+    // A proving key for the RAM zkSNARK.
+    using ram_zksnark_ppT = default_ram_zksnark_pp;
+
+    py::class_<ram_zksnark_proving_key<ram_zksnark_ppT>>(m, "ram_zksnark_proving_key")
+        .def(py::init<>())
+        .def(py::init<const ram_zksnark_proving_key<ram_zksnark_ppT> &>())
+        .def(
+            "__eq__", [](ram_zksnark_proving_key<ram_zksnark_ppT> const &self, ram_zksnark_proving_key<ram_zksnark_ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](ram_zksnark_proving_key<ram_zksnark_ppT> const &pk) {
+            std::ostringstream os;
+            os << pk.ap;
+            os << pk.pcd_pk;
+            return os;
+        })
+        .def("__istr__", [](ram_zksnark_proving_key<ram_zksnark_ppT> &pk) {
+            std::istringstream in;
+            in >> pk.ap;
+            in >> pk.pcd_pk;
+            return in;
+        });
+}
+
+void declare_ram_zksnark_verification_key(py::module &m)
+{
+    // A verification key for the RAM zkSNARK.
+    using ram_zksnark_ppT = default_ram_zksnark_pp;
+
+    py::class_<ram_zksnark_verification_key<ram_zksnark_ppT>>(m, "ram_zksnark_verification_key")
+        .def(py::init<>())
+        .def(py::init<const ram_zksnark_verification_key<ram_zksnark_ppT> &>())
+        .def(
+            "__eq__", [](ram_zksnark_verification_key<ram_zksnark_ppT> const &self, ram_zksnark_verification_key<ram_zksnark_ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](ram_zksnark_verification_key<ram_zksnark_ppT> const &vk) {
+            std::ostringstream os;
+            os << vk.ap;
+            os << vk.pcd_vk;
+            return os;
+        })
+        .def("__istr__", [](ram_zksnark_verification_key<ram_zksnark_ppT> &vk) {
+            std::istringstream in;
+            in >> vk.ap;
+            in >> vk.pcd_vk;
+            return in;
+        });
+}
+
+void declare_ram_zksnark_keypair(py::module &m)
+{
+    // A key pair for the RAM zkSNARK, which consists of a proving key and a verification key.
+    using ram_zksnark_ppT = default_ram_zksnark_pp;
+
+    py::class_<ram_zksnark_keypair<ram_zksnark_ppT>>(m, "ram_zksnark_keypair")
+        .def(py::init<>());
+}
+
+void declare_ram_zksnark_proof(py::module &m)
+{
+    // A proof for the RAM zkSNARK.
+    using ram_zksnark_ppT = default_ram_zksnark_pp;
+
+    py::class_<ram_zksnark_proof<ram_zksnark_ppT>>(m, "ram_zksnark_proof")
+        .def(py::init<>())
+        .def(py::init<const ram_zksnark_proof<ram_zksnark_ppT> &>())
+        .def("size_in_bits", &ram_zksnark_proof<ram_zksnark_ppT>::size_in_bits)
+        .def(
+            "__eq__", [](ram_zksnark_proof<ram_zksnark_ppT> const &self, ram_zksnark_proof<ram_zksnark_ppT> const &other) { return self == other; }, py::is_operator())
+        .def("__ostr__", [](ram_zksnark_proof<ram_zksnark_ppT> const &proof) {
+            std::ostringstream os;
+
+            os << proof.PCD_proof;
+            return os;
+        })
+        .def("__istr__", [](ram_zksnark_proof<ram_zksnark_ppT> &proof) {
+            std::istringstream in;
+            in >> proof.PCD_proof;
+            return in;
+        });
+}
+
+void declare_RAM_zksnark_Main_Algorithms(py::module &m)
+{
+    using ram_zksnark_ppT = default_ram_zksnark_pp;
+
+    // A generator algorithm for the RAM zkSNARK.
+    // Given a RAM constraint system CS, this algorithm produces proving and verification keys for CS.
+    m.def("ram_zksnark_generator", &ram_zksnark_generator<ram_zksnark_ppT>);
+
+    // A prover algorithm for the R1CS RAM zkSNARK.
+    m.def("ram_zksnark_prover", &ram_zksnark_prover<ram_zksnark_ppT>);
+
+    //  A verifier algorithm for the RAM zkSNARK.
+    m.def("ram_zksnark_verifier", &ram_zksnark_verifier<ram_zksnark_ppT>);
+}
+
+void init_zk_proof_systems_zksnark_ram_zksnark_ram_zksnark(py::module &m)
+{
+    declare_ram_zksnark_proving_key(m);
+    declare_ram_zksnark_verification_key(m);
+    declare_ram_zksnark_keypair(m);
+    declare_ram_zksnark_proof(m);
+    declare_RAM_zksnark_Main_Algorithms(m);
+}

--- a/src/PyZPK/zk_proof_systems/zksnark/ram_zksnark/run_ram_zksnark.cpp
+++ b/src/PyZPK/zk_proof_systems/zksnark/ram_zksnark/run_ram_zksnark.cpp
@@ -1,0 +1,21 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
+#include <libsnark/common/default_types/ram_zksnark_pp.hpp>
+#include <libsnark/zk_proof_systems/zksnark/ram_zksnark/examples/run_ram_zksnark.hpp>
+namespace py = pybind11;
+using namespace libsnark;
+using namespace libff;
+
+//  Declaration of functionality that runs the RAM zkSNARK for
+//  a given RAM example.
+
+void init_zk_proof_systems_ppzksnark_ram_zksnark_run_ram_zksnark(py::module &m)
+{
+    // Runs the zkSNARK (generator, prover, and verifier) for a given
+    // RAM example (specified by an architecture, boot trace, auxiliary input, and time bound).
+
+    using ram_zksnark_ppT = default_ram_zksnark_pp;
+
+    m.def("run_ram_zksnark", &run_ram_zksnark<ram_zksnark_ppT>);
+}

--- a/test/test_zk_proof_systems.py
+++ b/test/test_zk_proof_systems.py
@@ -267,3 +267,16 @@ def test_tbcs_ppzksnark():
 
     assert example.circuit.is_satisfied(
         primary_input_list, auxiliary_input_list)
+
+def test_ram_zksnark():
+    w = 32
+    k = 16
+    boot_trace_size_bound = 20
+    time_bound = 10
+    test_serialization = True
+    program_size = boot_trace_size_bound // 2
+    input_size = boot_trace_size_bound - program_size
+
+    assert 2*w/8*program_size < 1<<(w-1)
+    assert w/8*input_size < 1<<(w-1)
+    assert input_size >= 1


### PR DESCRIPTION
## Description
This PR adds bindings for RAM zksnark (zk_proof_systems)

closes #52 
## How has this been tested?
- This can be tested by running `pytest test` from the root folder.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
